### PR TITLE
Ret 824: Removed unused constants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation 'com.github.hmcts:et-common:0.0.18'
+    implementation 'com.github.hmcts:et-common:0.0.20'
     implementation 'com.github.hmcts:et-data-model:0.0.2'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/MultipleReferenceService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/MultipleReferenceService.java
@@ -10,14 +10,10 @@ import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.MultipleRefScot
 
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_USERS_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_DEV_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_USERS_BULK_CASE_TYPE_ID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,13 +25,9 @@ public class MultipleReferenceService {
 
     public synchronized String createReference(String caseTypeId, int numberCases) {
         switch (caseTypeId) {
-            case ENGLANDWALES_DEV_BULK_CASE_TYPE_ID:
-            case ENGLANDWALES_USERS_BULK_CASE_TYPE_ID:
             case ENGLANDWALES_BULK_CASE_TYPE_ID:
                 return generateOfficeReference(multipleRefEnglandWalesRepository, numberCases,
                         ENGLANDWALES_OFFICE_NUMBER, ENGLANDWALES_CASE_TYPE_ID);
-            case SCOTLAND_DEV_BULK_CASE_TYPE_ID:
-            case SCOTLAND_USERS_BULK_CASE_TYPE_ID:
             case SCOTLAND_BULK_CASE_TYPE_ID:
                 return generateOfficeReference(multipleRefScotlandRepository, numberCases,
                         SCOTLAND_OFFICE_NUMBER, SCOTLAND_CASE_TYPE_ID);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SingleReferenceService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SingleReferenceService.java
@@ -11,13 +11,9 @@ import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.SingleRefScotla
 import java.time.LocalDate;
 
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_USERS_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_DEV_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_USERS_CASE_TYPE_ID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,13 +26,9 @@ public class SingleReferenceService {
     public synchronized String createReference(String caseTypeId, int numberCases) {
         var currentYear = String.valueOf(LocalDate.now().getYear());
         switch (caseTypeId) {
-            case ENGLANDWALES_DEV_CASE_TYPE_ID:
-            case ENGLANDWALES_USERS_CASE_TYPE_ID:
             case ENGLANDWALES_CASE_TYPE_ID:
                 return generateOfficeReference(singleRefEnglandWalesRepository, currentYear, numberCases,
                         ENGLANDWALES_OFFICE_NUMBER, ENGLANDWALES_CASE_TYPE_ID);
-            case SCOTLAND_DEV_CASE_TYPE_ID:
-            case SCOTLAND_USERS_CASE_TYPE_ID:
             case SCOTLAND_CASE_TYPE_ID:
                 return generateOfficeReference(singleRefScotlandRepository, currentYear, numberCases,
                         SCOTLAND_OFFICE_NUMBER, SCOTLAND_CASE_TYPE_ID);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SubMultipleReferenceService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SubMultipleReferenceService.java
@@ -10,12 +10,8 @@ import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.SubMultipleRefS
 
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_BULK_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_USERS_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_DEV_BULK_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_USERS_BULK_CASE_TYPE_ID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,13 +24,9 @@ public class SubMultipleReferenceService {
     public synchronized String createReference(String caseTypeId, String multipleReference, int numberCases) {
         switch (caseTypeId) {
             case ENGLANDWALES_BULK_CASE_TYPE_ID:
-            case ENGLANDWALES_DEV_BULK_CASE_TYPE_ID:
-            case ENGLANDWALES_USERS_BULK_CASE_TYPE_ID:
                 return generateOfficeReference(subMultipleRefEnglandWalesRepository, numberCases, multipleReference,
                         ENGLANDWALES_CASE_TYPE_ID);
             case SCOTLAND_BULK_CASE_TYPE_ID:
-            case SCOTLAND_DEV_BULK_CASE_TYPE_ID:
-            case SCOTLAND_USERS_BULK_CASE_TYPE_ID:
                 return generateOfficeReference(subMultipleRefScotlandRepository, numberCases, multipleReference,
                         SCOTLAND_CASE_TYPE_ID);
             default:

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/ListingHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/ListingHelperTest.java
@@ -30,7 +30,38 @@ import java.util.Objects;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.*;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.BROUGHT_FORWARD_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASES_AWAITING_JUDGMENT_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASES_COMPLETED_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.CASE_SOURCE_LOCAL_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMS_ACCEPTED_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_LISTING_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARINGS_TO_JUDGEMENTS_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_DOC_ETCL;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_DOC_IT56;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_DOC_IT57;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_ETCL_PRESS_LIST;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_ETCL_PUBLIC;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_ETCL_STAFF;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.IT56_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.IT57_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.LIVE_CASELOAD_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.MEMBER_DAYS_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.PRESS_LIST_CAUSE_LIST_RANGE_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.PRESS_LIST_CAUSE_LIST_SINGLE_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.PUBLIC_CASE_CAUSE_LIST_ROOM_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.PUBLIC_CASE_CAUSE_LIST_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.RANGE_HEARING_DATE_TYPE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_LISTING_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SERVING_CLAIMS_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SINGLE_HEARING_DATE_TYPE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.STAFF_CASE_CAUSE_LIST_ROOM_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.STAFF_CASE_CAUSE_LIST_TEMPLATE;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.TIME_TO_FIRST_HEARING_REPORT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 
 public class ListingHelperTest {
 
@@ -1004,16 +1035,8 @@ public class ListingHelperTest {
 
     @Test
     public void getListingCaseTypeId() {
-        assertEquals(ENGLANDWALES_DEV_CASE_TYPE_ID,
-                UtilHelper.getListingCaseTypeId(ENGLANDWALES_DEV_LISTING_CASE_TYPE_ID));
-        assertEquals(ENGLANDWALES_USERS_CASE_TYPE_ID,
-                UtilHelper.getListingCaseTypeId(ENGLANDWALES_USERS_LISTING_CASE_TYPE_ID));
         assertEquals(ENGLANDWALES_CASE_TYPE_ID,
                 UtilHelper.getListingCaseTypeId(ENGLANDWALES_LISTING_CASE_TYPE_ID));
-        assertEquals(SCOTLAND_DEV_CASE_TYPE_ID,
-                UtilHelper.getListingCaseTypeId(SCOTLAND_DEV_LISTING_CASE_TYPE_ID));
-        assertEquals(SCOTLAND_USERS_CASE_TYPE_ID,
-                UtilHelper.getListingCaseTypeId(SCOTLAND_USERS_LISTING_CASE_TYPE_ID));
         assertEquals(SCOTLAND_CASE_TYPE_ID,
                 UtilHelper.getListingCaseTypeId(SCOTLAND_LISTING_CASE_TYPE_ID));
     }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BulkUpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BulkUpdateServiceTest.java
@@ -47,8 +47,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ACCEPTED_STATE;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_BULK_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_BULK_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MULTIPLE_CASE_TYPE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SUBMITTED_STATE;
 import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ERROR_MESSAGE;
@@ -94,7 +94,7 @@ public class BulkUpdateServiceTest {
 
         bulkDetails.setJurisdiction("TRIBUNALS");
         bulkDetails.setCaseData(bulkData);
-        bulkDetails.setCaseTypeId(ENGLANDWALES_DEV_BULK_CASE_TYPE_ID);
+        bulkDetails.setCaseTypeId(ENGLANDWALES_BULK_CASE_TYPE_ID);
         bulkDetails.setCaseId("2300001/2019");
         bulkRequest.setCaseDetails(bulkDetails);
 
@@ -135,7 +135,7 @@ public class BulkUpdateServiceTest {
 
     @Test(expected = Exception.class)
     public void caseUpdateFieldsRequestException() throws IOException {
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenThrow(new InternalException(ERROR_MESSAGE));
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenThrow(new InternalException(ERROR_MESSAGE));
         when(ccdClient.startEventForCase(anyString(), anyString(), anyString(), anyString())).thenReturn(ccdRequest);
         when(ccdClient.submitEventForCase(anyString(), any(), anyString(), anyString(), any(), anyString())).thenReturn(submitEvent);
         bulkUpdateService.caseUpdateFieldsRequest(bulkRequest.getCaseDetails(), searchTypeItem, "authToken",
@@ -144,7 +144,7 @@ public class BulkUpdateServiceTest {
 
     @Test
     public void caseUpdateFieldsRequest() throws IOException {
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
         when(ccdClient.startEventForCase(anyString(), anyString(), anyString(), anyString())).thenReturn(ccdRequest);
         when(ccdClient.submitEventForCase(anyString(), any(), anyString(), anyString(), any(), anyString())).thenReturn(submitEvent);
         bulkUpdateService.caseUpdateFieldsRequest(bulkRequest.getCaseDetails(), searchTypeItem, "authToken",
@@ -153,7 +153,7 @@ public class BulkUpdateServiceTest {
 
     @Test
     public void caseUpdateFieldsWithNewValuesRequest() throws IOException {
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
         when(ccdClient.startEventForCase(anyString(), anyString(), anyString(), anyString())).thenReturn(ccdRequest);
         when(ccdClient.submitEventForCase(anyString(), any(), anyString(), anyString(), any(), anyString())).thenReturn(submitEvent);
         bulkUpdateService.caseUpdateFieldsRequest(getBulkDetailsWithValues(), searchTypeItem, "authToken",
@@ -169,11 +169,11 @@ public class BulkUpdateServiceTest {
         List<SubmitBulkEvent> submitBulkEventList = new ArrayList<>(Collections.singletonList(submitBulkEvent));
         BulkCasesPayload bulkCasesPayload = new BulkCasesPayload();
         bulkCasesPayload.setSubmitEvents(new ArrayList<>(Collections.singleton(submitEvent)));
-        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
-        when(ccdClient.retrieveBulkCasesElasticSearch("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkData.getMultipleReference())).thenReturn(submitBulkEventList);
-        assert(bulkUpdateService.bulkUpdateLogic(getBulkDetailsCompleteWithValues(getBulkDetailsWithValues()),
+        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
+        when(ccdClient.retrieveBulkCasesElasticSearch("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkData.getMultipleReference())).thenReturn(submitBulkEventList);
+        assert (bulkUpdateService.bulkUpdateLogic(getBulkDetailsCompleteWithValues(getBulkDetailsWithValues()),
                 "authToken").getBulkDetails() != null);
     }
 
@@ -196,9 +196,9 @@ public class BulkUpdateServiceTest {
         multipleTypeItem.setValue(multipleTypeLead);
         bulkDetails.getCaseData().getMultipleCollection().add(0, multipleTypeItem);
         bulkCasesPayload.setSubmitEvents(new ArrayList<>(Collections.singleton(submitEvent)));
-        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), "1234")).thenReturn(submitEvent);
+        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), "1234")).thenReturn(submitEvent);
         assert (bulkUpdateService.bulkUpdateLogic(bulkDetails,
                 "authToken").getBulkDetails() != null);
     }
@@ -212,10 +212,10 @@ public class BulkUpdateServiceTest {
         List<SubmitBulkEvent> submitBulkEventList = new ArrayList<>(Collections.singletonList(submitBulkEvent));
         BulkCasesPayload bulkCasesPayload = new BulkCasesPayload();
         bulkCasesPayload.setSubmitEvents(new ArrayList<>(Collections.singleton(submitEvent)));
-        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
-        when(ccdClient.retrieveBulkCasesElasticSearch("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkData.getMultipleReference())).thenThrow(new InternalException(ERROR_MESSAGE));
+        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
+        when(ccdClient.retrieveBulkCasesElasticSearch("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkData.getMultipleReference())).thenThrow(new InternalException(ERROR_MESSAGE));
         bulkUpdateService.bulkUpdateLogic(getBulkDetailsCompleteWithValues(getBulkDetailsWithValues()), "authToken");
     }
 
@@ -226,9 +226,9 @@ public class BulkUpdateServiceTest {
         bulkData.setMultipleReference("1111");
         submitBulkEvent.setCaseData(bulkData);
         List<SubmitBulkEvent> submitBulkEventList = new ArrayList<>(Collections.singletonList(submitBulkEvent));
-        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
-        assert(!bulkUpdateService.bulkUpdateLogic(getBulkDetailsWithValues(), "authToken").getErrors().isEmpty());
+        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        assert (!bulkUpdateService.bulkUpdateLogic(getBulkDetailsWithValues(), "authToken").getErrors().isEmpty());
     }
 
     @Test
@@ -241,9 +241,9 @@ public class BulkUpdateServiceTest {
         BulkCasesPayload bulkCasesPayload = new BulkCasesPayload();
         bulkCasesPayload.setSubmitEvents(new ArrayList<>(Collections.singleton(submitEvent)));
         when(ccdClient.startEventForCase(anyString(), anyString(), anyString(), anyString())).thenThrow(new InternalException(ERROR_MESSAGE));
-        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
-        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_DEV_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
+        when(ccdClient.retrieveBulkCases("authToken", ENGLANDWALES_BULK_CASE_TYPE_ID, bulkDetails.getJurisdiction())).thenReturn(submitBulkEventList);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), searchTypeItem.getId())).thenReturn(submitEvent);
+        when(ccdClient.retrieveCase("authToken", ENGLANDWALES_CASE_TYPE_ID, bulkDetails.getJurisdiction(), null)).thenReturn(submitEvent);
         assertEquals("[Multiple reference does not exist or it is the same as the current multiple case]", bulkUpdateService.bulkUpdateLogic(getBulkDetailsCompleteWithValues(getBulkDetailsWithValues()),
                 "authToken").getErrors().toString());
     }
@@ -284,7 +284,7 @@ public class BulkUpdateServiceTest {
         bulkData.setManagingOffice(TribunalOffice.GLASGOW.getOfficeName());
         bulkDetails.setCaseData(bulkData);
         bulkDetails.setJurisdiction("TRIBUNALS");
-        bulkDetails.setCaseTypeId(ENGLANDWALES_DEV_BULK_CASE_TYPE_ID);
+        bulkDetails.setCaseTypeId(ENGLANDWALES_BULK_CASE_TYPE_ID);
         return bulkDetails;
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -49,7 +49,6 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ABOUT_TO_SUBMIT_EVENT_CALLBACK;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.FLAG_ECC;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.HEARING_STATUS_LISTED;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MID_EVENT_CALLBACK;
@@ -62,9 +61,9 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @RunWith(SpringJUnit4ClassRunner.class)
 public class CaseManagementForCaseWorkerServiceTest {
 
+    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     @InjectMocks
     private CaseManagementForCaseWorkerService caseManagementForCaseWorkerService;
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private CCDRequest scotlandCcdRequest1;
     private CCDRequest scotlandCcdRequest2;
     private CCDRequest scotlandCcdRequest3;
@@ -141,7 +140,7 @@ public class CaseManagementForCaseWorkerServiceTest {
         caseData.setRespondentECC(createRespondentECC());
         manchesterCaseDetails.setCaseData(caseData);
         manchesterCaseDetails.setCaseId("123456");
-        manchesterCaseDetails.setCaseTypeId(ENGLANDWALES_DEV_CASE_TYPE_ID);
+        manchesterCaseDetails.setCaseTypeId(ENGLANDWALES_CASE_TYPE_ID);
         manchesterCaseDetails.setJurisdiction("TRIBUNALS");
         manchesterCcdRequest.setCaseDetails(manchesterCaseDetails);
 
@@ -185,6 +184,7 @@ public class CaseManagementForCaseWorkerServiceTest {
             assertEquals(NO, respondentSumTypeItem.getValue().getResponseReceived());
         }
     }
+
     @Test
     public void caseDataDefaultsResetResponseRespondentAddress() {
         CaseData caseData = scotlandCcdRequest1.getCaseDetails().getCaseData();
@@ -217,10 +217,10 @@ public class CaseManagementForCaseWorkerServiceTest {
         CaseData caseData = scotlandCcdRequest1.getCaseDetails().getCaseData();
         caseData.getRespondentCollection().get(0).getValue().setResponseReceived(YES);
         caseManagementForCaseWorkerService.caseDataDefaults(caseData);
-        assertEquals(YES,caseData.getRespondentCollection().get(0).getValue().getResponseReceived());
+        assertEquals(YES, caseData.getRespondentCollection().get(0).getValue().getResponseReceived());
         for (RespondentSumTypeItem respondentSumTypeItem : caseData.getRespondentCollection()) {
             if (respondentSumTypeItem != caseData.getRespondentCollection().get(0))
-            assertEquals(NO, respondentSumTypeItem.getValue().getResponseReceived());
+                assertEquals(NO, respondentSumTypeItem.getValue().getResponseReceived());
         }
     }
 
@@ -566,7 +566,7 @@ public class CaseManagementForCaseWorkerServiceTest {
         c2.setId(UUID.randomUUID().toString());
         c1.setValue(counterClaimType1);
         c2.setValue(counterClaimType2);
-        manchesterCcdRequest.getCaseDetails().getCaseData().setEccCases(Arrays.asList(c1,c2));
+        manchesterCcdRequest.getCaseDetails().getCaseData().setEccCases(Arrays.asList(c1, c2));
         when(caseRetrievalForCaseWorkerService.casesRetrievalESRequest(isA(String.class), eq(AUTH_TOKEN), isA(String.class), isA(List.class)))
                 .thenReturn(new ArrayList(Collections.singleton(submitEvent)));
         assertEquals(c1.getValue().getCounterClaim(), caseManagementForCaseWorkerService.createECC(manchesterCcdRequest.getCaseDetails(), AUTH_TOKEN,

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseUpdateForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseUpdateForCaseWorkerServiceTest.java
@@ -21,9 +21,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.INDIVIDUAL_TYPE_CLAIMANT;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_DEV_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SINGLE_CASE_TYPE;
 import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ERROR_MESSAGE;
 
@@ -51,7 +51,7 @@ public class CaseUpdateForCaseWorkerServiceTest {
         englandWalesCaseDetails.setCaseData(new CaseData());
         englandWalesCaseDetails.getCaseData().setManagingOffice(TribunalOffice.MANCHESTER.getOfficeName());
         englandWalesCaseDetails.setCaseId("123456");
-        englandWalesCaseDetails.setCaseTypeId(ENGLANDWALES_DEV_CASE_TYPE_ID);
+        englandWalesCaseDetails.setCaseTypeId(ENGLANDWALES_CASE_TYPE_ID);
         englandWalesCaseDetails.setJurisdiction("TRIBUNALS");
         englandWalesCcdRequest.setCaseDetails(englandWalesCaseDetails);
 
@@ -60,7 +60,7 @@ public class CaseUpdateForCaseWorkerServiceTest {
         scotlandCaseDetails.setCaseData(new CaseData());
         scotlandCaseDetails.getCaseData().setManagingOffice(TribunalOffice.GLASGOW.getOfficeName());
         scotlandCaseDetails.setCaseId("123456");
-        scotlandCaseDetails.setCaseTypeId(SCOTLAND_DEV_CASE_TYPE_ID);
+        scotlandCaseDetails.setCaseTypeId(SCOTLAND_CASE_TYPE_ID);
         scotlandCaseDetails.setJurisdiction("TRIBUNALS");
         scotlandCcdRequest.setCaseDetails(scotlandCaseDetails);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentGenerationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/DocumentGenerationServiceTest.java
@@ -14,9 +14,12 @@ import uk.gov.hmcts.ecm.common.model.bulk.BulkDocumentInfo;
 import uk.gov.hmcts.ecm.common.model.bulk.BulkRequest;
 import uk.gov.hmcts.ecm.common.model.bulk.items.SearchTypeItem;
 import uk.gov.hmcts.ecm.common.model.bulk.types.SearchType;
-import uk.gov.hmcts.ecm.common.model.ccd.*;
+import uk.gov.hmcts.ecm.common.model.ccd.CCDRequest;
+import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
+import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
+import uk.gov.hmcts.ecm.common.model.ccd.DocumentInfo;
+import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.ccd.types.CorrespondenceScotType;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.*;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 
 import java.io.IOException;
@@ -33,6 +36,12 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_BULK_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_BULK_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ERROR_MESSAGE;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -83,7 +92,7 @@ public class DocumentGenerationServiceTest {
         searchTypeItem.setValue(searchType);
         bulkData.setSearchCollection(new ArrayList<>(Collections.singletonList(searchTypeItem)));
         bulkDetails.setCaseData(bulkData);
-        bulkDetails.setCaseTypeId(ENGLANDWALES_DEV_BULK_CASE_TYPE_ID);
+        bulkDetails.setCaseTypeId(ENGLANDWALES_BULK_CASE_TYPE_ID);
         bulkRequest.setCaseDetails(bulkDetails);
         documentGenerationService = new DocumentGenerationService(tornadoService, ccdClient);
         documentInfo = DocumentInfo.builder().description("resources/exampleV1.json").build();
@@ -335,7 +344,7 @@ public class DocumentGenerationServiceTest {
     public void clearUserChoicesForMultiplesScotland() {
         BulkDetails bulkDetails = bulkRequest.getCaseDetails();
         bulkDetails.setCaseTypeId(SCOTLAND_BULK_CASE_TYPE_ID);
-        documentGenerationService.clearUserChoicesForMultiples (bulkDetails);
+        documentGenerationService.clearUserChoicesForMultiples(bulkDetails);
         assertNull(bulkDetails.getCaseData().getCorrespondenceScotType());
     }
 
@@ -343,7 +352,7 @@ public class DocumentGenerationServiceTest {
     public void clearUserChoicesForMultiplesEngland() {
         BulkDetails bulkDetails = bulkRequest.getCaseDetails();
         bulkDetails.setCaseTypeId(ENGLANDWALES_BULK_CASE_TYPE_ID);
-        documentGenerationService.clearUserChoicesForMultiples (bulkDetails);
+        documentGenerationService.clearUserChoicesForMultiples(bulkDetails);
         assertNull(bulkDetails.getCaseData().getCorrespondenceType());
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/MultipleReferenceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/MultipleReferenceServiceTest.java
@@ -13,14 +13,10 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_DEV_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_USERS_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_DEV_BULK_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_OFFICE_NUMBER;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_USERS_BULK_CASE_TYPE_ID;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class MultipleReferenceServiceTest {
@@ -40,10 +36,6 @@ public class MultipleReferenceServiceTest {
                 .thenReturn("00015");
         var expectedReference = ENGLANDWALES_OFFICE_NUMBER + "00015";
 
-        assertEquals(expectedReference,
-                multipleReferenceService.createReference(ENGLANDWALES_DEV_BULK_CASE_TYPE_ID, 1));
-        assertEquals(expectedReference,
-                multipleReferenceService.createReference(ENGLANDWALES_USERS_BULK_CASE_TYPE_ID, 1));
         assertEquals(expectedReference, multipleReferenceService.createReference(ENGLANDWALES_BULK_CASE_TYPE_ID, 1));
     }
 
@@ -62,8 +54,6 @@ public class MultipleReferenceServiceTest {
         when(multipleRefScotlandRepository.ethosMultipleCaseRefGen(1, SCOTLAND_CASE_TYPE_ID)).thenReturn("00015");
         var expectedReference = SCOTLAND_OFFICE_NUMBER + "00015";
 
-        assertEquals(expectedReference, multipleReferenceService.createReference(SCOTLAND_DEV_BULK_CASE_TYPE_ID, 1));
-        assertEquals(expectedReference, multipleReferenceService.createReference(SCOTLAND_USERS_BULK_CASE_TYPE_ID, 1));
         assertEquals(expectedReference, multipleReferenceService.createReference(SCOTLAND_BULK_CASE_TYPE_ID, 1));
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SingleReferenceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SingleReferenceServiceTest.java
@@ -6,13 +6,17 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.*;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.SingleRefEnglandWalesRepository;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.SingleRefScotlandRepository;
 
 import java.time.LocalDate;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.*;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_OFFICE_NUMBER;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_OFFICE_NUMBER;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SingleReferenceServiceTest {
@@ -36,7 +40,7 @@ public class SingleReferenceServiceTest {
         when(singleRefEnglandWalesRepository.ethosCaseRefGen(1, Integer.parseInt(currentYear),
                 ENGLANDWALES_CASE_TYPE_ID)).thenReturn("00012/" + currentYear);
         String englandWalesRef = ENGLANDWALES_OFFICE_NUMBER + "00012/" + currentYear;
-        assertEquals(singleReferenceService.createReference(ENGLANDWALES_DEV_CASE_TYPE_ID, 1), englandWalesRef);
+        assertEquals(singleReferenceService.createReference(ENGLANDWALES_CASE_TYPE_ID, 1), englandWalesRef);
     }
 
     @Test
@@ -44,7 +48,7 @@ public class SingleReferenceServiceTest {
         when(singleRefEnglandWalesRepository.ethosCaseRefGen(2, Integer.parseInt(currentYear),
                 ENGLANDWALES_CASE_TYPE_ID)).thenReturn("00012/" + currentYear);
         String manchesterRef = ENGLANDWALES_OFFICE_NUMBER + "00012/" + currentYear;
-        assertEquals(singleReferenceService.createReference(ENGLANDWALES_DEV_CASE_TYPE_ID, 2), manchesterRef);
+        assertEquals(singleReferenceService.createReference(ENGLANDWALES_CASE_TYPE_ID, 2), manchesterRef);
     }
 
     @Test
@@ -52,7 +56,7 @@ public class SingleReferenceServiceTest {
         when(singleRefScotlandRepository.ethosCaseRefGen(1, Integer.parseInt(currentYear),
                 SCOTLAND_CASE_TYPE_ID)).thenReturn("00012/" + currentYear);
         String scotlandRef = SCOTLAND_OFFICE_NUMBER + "00012/" + currentYear;
-        assertEquals(singleReferenceService.createReference(SCOTLAND_DEV_CASE_TYPE_ID, 1), scotlandRef);
+        assertEquals(singleReferenceService.createReference(SCOTLAND_CASE_TYPE_ID, 1), scotlandRef);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RET-824](https://tools.hmcts.net/jira/browse/RET-824)

### Change description ###

* Removes unused constants from main and test classes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
