### PR TITLE
Add JUnit vintage engine to enable JUnit 4 tests with Spring Boot 2.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ repositories {
 
 ext {
     feignVersion = '11.8'
-    junitJupiterVersion = '5.6.3'
+    junitJupiterVersion = '5.8.1'
     log4JVersion = '2.17.1'
     logbackVersion = '1.2.11'
     pact_version = '4.1.7'
@@ -304,7 +304,8 @@ dependencies {
     testImplementation (group: 'org.docx4j', name: 'docx4j', version: '6.1.2') {
         exclude module: 'slf4j-log4j12'
     }
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitJupiterVersion
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
     // Contract Tests
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: pact_version


### PR DESCRIPTION
### Change description ###
Add JUnit vintage engine to enable JUnit 4 tests with Spring Boot 2.6.4


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
