### PR TITLE
Ret 1778

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/AddJudgeController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/AddJudgeController.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.controllers.admin;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.CCDCallbackResponse;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.CCDRequest;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.AddJudgeService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AddJudgeController {
+
+    private final VerifyTokenService verifyTokenService;
+    private final AddJudgeService addJudgeService;
+
+    @PostMapping(value = "/addJudge", consumes = APPLICATION_JSON_VALUE)
+    @Operation(summary = "Add Judge")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Accessed successfully"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "409", description = "Conflict"),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error")
+    })
+    public ResponseEntity<CCDCallbackResponse> addJudge(
+            @RequestHeader("Authorization") String userToken,
+            @RequestBody CCDRequest ccdRequest) {
+
+        if (!verifyTokenService.verifyTokenSignature(userToken)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN.value()).build();
+        }
+
+        AdminData adminData = ccdRequest.getCaseDetails().getAdminData();
+        if (!addJudgeService.saveJudge(adminData)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT.value()).build();
+        }
+
+        return CCDCallbackResponse.getCallbackRespEntityNoErrors(adminData);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/admin/AdminData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/admin/AdminData.java
@@ -15,4 +15,14 @@ public class AdminData {
     private ImportFile staffImportFile;
     @JsonProperty("venueImport")
     private VenueImport venueImport;
+
+    // For adding judge
+    @JsonProperty("tribunalOffice")
+    private String tribunalOffice;
+    @JsonProperty("judgeCode")
+    private String judgeCode;
+    @JsonProperty("judgeName")
+    private String judgeName;
+    @JsonProperty("employmentStatus")
+    private String employmentStatus;
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/repository/JudgeRepository.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/repository/JudgeRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface JudgeRepository extends JpaRepository<Judge, Integer> {
     List<Judge> findByTribunalOffice(TribunalOffice tribunalOffice);
+
+    boolean existsByCodeOrName(String code, String name);
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/admin/AddJudgeService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/admin/AddJudgeService.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.service.admin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.referencedata.Judge;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.referencedata.JudgeEmploymentStatus;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.JudgeRepository;
+
+@Service
+@Slf4j
+public class AddJudgeService {
+
+    private final JudgeRepository judgeRepository;
+
+    public AddJudgeService(JudgeRepository judgeRepository) {
+        this.judgeRepository = judgeRepository;
+    }
+
+    public boolean saveJudge(AdminData adminData) {
+        var judge =  new Judge();
+        judge.setCode(adminData.getJudgeCode());
+        judge.setName(adminData.getJudgeName());
+        judge.setEmploymentStatus(JudgeEmploymentStatus.valueOf(adminData.getEmploymentStatus()));
+        judge.setTribunalOffice(TribunalOffice.valueOf(adminData.getTribunalOffice()));
+
+        if (!judgeRepository.existsByCodeOrName(adminData.getJudgeCode(), adminData.getJudgeName())) {
+            judgeRepository.save(judge);
+        } else {
+            log.error("A judge with the same name or code already exists.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/AddJudgeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/AddJudgeControllerTest.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.controllers.admin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.AddJudgeService;
+import uk.gov.hmcts.ethos.replacement.docmosis.utils.AdminDataBuilder;
+import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest({AddJudgeController.class, JsonMapper.class})
+class AddJudgeControllerTest {
+    @MockBean
+    private VerifyTokenService verifyTokenService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
+    @MockBean
+    private AddJudgeService addJudgeService;
+
+    @Test
+    void testAddJudgeSuccess() throws Exception {
+        var ccdRequest = AdminDataBuilder
+                .builder()
+                .withJudgeData("testCode", "testName", "ABERDEEN", "SALARIED")
+                .buildAsCCDRequest();
+
+        var token = "some-token";
+        when(verifyTokenService.verifyTokenSignature(token)).thenReturn(true);
+        when(addJudgeService.saveJudge(ccdRequest.getCaseDetails().getAdminData())).thenReturn(true);
+
+        mockMvc.perform(post("/admin/addJudge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", token)
+                        .content(jsonMapper.toJson(ccdRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", notNullValue()))
+                .andExpect(jsonPath("$.errors", nullValue()))
+                .andExpect(jsonPath("$.warnings", nullValue()));
+        verify(addJudgeService, times(1)).saveJudge(ccdRequest.getCaseDetails().getAdminData());
+    }
+
+    @Test
+    void testAddJudgeConflict() throws Exception {
+        var ccdRequest = AdminDataBuilder
+                .builder()
+                .withJudgeData("testCode", "testName", "ABERDEEN", "SALARIED")
+                .buildAsCCDRequest();
+
+        var token = "some-token";
+        when(verifyTokenService.verifyTokenSignature(token)).thenReturn(true);
+        when(addJudgeService.saveJudge(ccdRequest.getCaseDetails().getAdminData())).thenReturn(false);
+
+        mockMvc.perform(post("/admin/addJudge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", token)
+                        .content(jsonMapper.toJson(ccdRequest)))
+                .andExpect(status().isConflict());
+        verify(addJudgeService, times(1)).saveJudge(ccdRequest.getCaseDetails().getAdminData());
+    }
+
+    @Test
+    void testAddJudgeInvalidToken() throws Exception {
+        var ccdRequest = AdminDataBuilder
+                .builder()
+                .withJudgeData("testCode", "testName", "ABERDEEN", "SALARIED")
+                .buildAsCCDRequest();
+
+        var token = "some-token";
+        when(verifyTokenService.verifyTokenSignature(token)).thenReturn(false);
+
+        mockMvc.perform(post("/admin/addJudge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", token)
+                        .content(jsonMapper.toJson(ccdRequest)))
+                .andExpect(status().isForbidden());
+        verify(addJudgeService, never()).saveJudge(ccdRequest.getCaseDetails().getAdminData());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/admin/AddJudgeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/admin/AddJudgeServiceTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.service.admin;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.referencedata.Judge;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.referencedata.JudgeEmploymentStatus;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.JudgeRepository;
+
+import static org.mockito.Mockito.*;
+
+class AddJudgeServiceTest {
+    private JudgeRepository judgeRepository;
+    private final String judgeCode = "testCode";
+    private final String judgeName = "testName";
+
+    @BeforeEach
+    void setup() {
+        judgeRepository = mock(JudgeRepository.class);
+    }
+
+    @Test
+    void shouldSaveJudge() {
+        var adminData = createAdminData(judgeCode, judgeName, "ABERDEEN", "SALARIED");
+        var addJudgeService = new AddJudgeService(judgeRepository);
+        when(judgeRepository.existsByCodeOrName(judgeCode, judgeName)).thenReturn(false);
+        Assert.assertEquals(addJudgeService.saveJudge(adminData), true);
+        verify(judgeRepository, times(1)).save(createJudge(adminData));
+    }
+
+    @Test
+    void shouldReturnFalseIfJudgeExists() {
+        var adminData = createAdminData(judgeCode, judgeName, "ABERDEEN", "SALARIED");
+        var addJudgeService = new AddJudgeService(judgeRepository);
+        when(judgeRepository.existsByCodeOrName(judgeCode, judgeName)).thenReturn(true);
+        Assert.assertEquals(addJudgeService.saveJudge(adminData), false);
+        verify(judgeRepository, never()).save(createJudge(adminData));
+    }
+
+    private AdminData createAdminData(String judgeCode, String judgeName, String tribunalOffice, String employmentStatus) {
+        AdminData adminData = new AdminData();
+        adminData.setJudgeCode(judgeCode);
+        adminData.setJudgeName(judgeName);
+        adminData.setTribunalOffice(tribunalOffice);
+        adminData.setEmploymentStatus(employmentStatus);
+        return adminData;
+    }
+
+    private Judge createJudge(AdminData adminData) {
+        var judge =  new Judge();
+        judge.setCode(adminData.getJudgeCode());
+        judge.setName(adminData.getJudgeName());
+        judge.setEmploymentStatus(JudgeEmploymentStatus.valueOf(adminData.getEmploymentStatus()));
+        judge.setTribunalOffice(TribunalOffice.valueOf(adminData.getTribunalOffice()));
+        return judge;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/utils/AdminDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/utils/AdminDataBuilder.java
@@ -40,6 +40,23 @@ public class AdminDataBuilder {
         return this;
     }
 
+    public AdminDataBuilder withJudgeData(String judgeCode, String judgeName, String tribunalOffice, String employmentStatus) {
+        if (adminData.getJudgeCode() == null) {
+            adminData.setJudgeCode(judgeCode);
+        }
+        if (adminData.getJudgeName() == null) {
+            adminData.setJudgeName(judgeName);
+        }
+        if (adminData.getTribunalOffice() == null) {
+            adminData.setTribunalOffice(tribunalOffice);
+        }
+        if (adminData.getEmploymentStatus() == null) {
+            adminData.setEmploymentStatus(employmentStatus);
+        }
+
+        return this;
+    }
+
     public CCDRequest buildAsCCDRequest() {
         var ccdRequest = new CCDRequest();
         var caseDetails = new CaseDetails();


### PR DESCRIPTION
[RET-1778](https://tools.hmcts.net/jira/browse/RET-1778)


Enable an admin user to be able to add a new judge to the ECM reference data.

The functionality should be available from the ECM Admin case type.

The ECM Admin case type should include a new event/step called Add judge.

The event should input the tribunal office, judge code, judge name, judge employment status.

tribunal office = droplist of all offices in England/Wales plus single entry for Scotland.

code = textbox

name = textbox

employment status = dropdown list with entries Fee Paid, Salaried, Unknown

All fields are mandatory.

The judge code and name should not already exist for the tribunal office.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
