### PR TITLE
RET-1852: New endpoint for returning serving documents other type name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: '2.13.2.20220328', ext: 'pom'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.1'
     implementation group: 'com.github.hmcts', name: 'et-common', version:'0.0.35'
-    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.7'
+    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.8'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: '2.13.2.20220328', ext: 'pom'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.1'
     implementation group: 'com.github.hmcts', name: 'et-common', version:'0.0.35'
-    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.5'
+    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.7'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -1164,9 +1164,13 @@ public class CaseActionsForCaseWorkerController {
         StringBuilder sb = new StringBuilder();
         for (DocumentTypeItem doc : ccdRequest.getCaseDetails().getCaseData().getServingDocumentCollection()) {
             if (doc.getValue().getTypeOfDocument().equals(SERVING_DOCUMENT_OTHER_TYPE)) {
-                sb.append("**<big>" + doc.getValue().getUploadedDocument().getDocumentFilename() + "</big>**<br/>");
+                sb.append("**<big>");
+                sb.append(doc.getValue().getUploadedDocument().getDocumentFilename());
+                sb.append("</big>**<br/>");
                 if (doc.getValue().getShortDescription() != null) {
-                    sb.append("<small>" + doc.getValue().getShortDescription() + "</small><br/>");
+                    sb.append("<small>");
+                    sb.append(doc.getValue().getShortDescription());
+                    sb.append("</small><br/>");
                 } else {
                     sb.append("<small>No description<small/><br/>");
                 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -1161,7 +1161,7 @@ public class CaseActionsForCaseWorkerController {
 
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (DocumentTypeItem doc : ccdRequest.getCaseDetails().getCaseData().getServingDocumentCollection()) {
             if (doc.getValue().getTypeOfDocument().equals(SERVING_DOCUMENT_OTHER_TYPE)) {
                 sb.append("**<big>" + doc.getValue().getUploadedDocument().getDocumentFilename() + "</big>**<br/>");

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -1162,7 +1162,7 @@ public class CaseActionsForCaseWorkerController {
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
 
         StringBuilder sb = new StringBuilder();
-        for (DocumentTypeItem doc : ccdRequest.getCaseDetails().getCaseData().getServingDocumentCollection()) {
+        for (DocumentTypeItem doc : caseData.getServingDocumentCollection()) {
             if (doc.getValue().getTypeOfDocument().equals(SERVING_DOCUMENT_OTHER_TYPE)) {
                 sb.append("**<big>");
                 sb.append(doc.getValue().getUploadedDocument().getDocumentFilename());

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -1160,23 +1160,7 @@ public class CaseActionsForCaseWorkerController {
         }
 
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
-
-        StringBuilder sb = new StringBuilder();
-        for (DocumentTypeItem doc : caseData.getServingDocumentCollection()) {
-            if (doc.getValue().getTypeOfDocument().equals(SERVING_DOCUMENT_OTHER_TYPE)) {
-                sb.append("**<big>");
-                sb.append(doc.getValue().getUploadedDocument().getDocumentFilename());
-                sb.append("</big>**<br/>");
-                if (doc.getValue().getShortDescription() != null) {
-                    sb.append("<small>");
-                    sb.append(doc.getValue().getShortDescription());
-                    sb.append("</small><br/>");
-                } else {
-                    sb.append("<small>No description<small/><br/>");
-                }
-            }
-        }
-        caseData.setOtherTypeDocumentName(sb.toString());
+        caseData.setOtherTypeDocumentName(generateOtherTypeDocumentName(caseData.getServingDocumentCollection()));
 
         return getCallbackRespEntityNoErrors(ccdRequest.getCaseDetails().getCaseData());
     }
@@ -1192,5 +1176,20 @@ public class CaseActionsForCaseWorkerController {
                     ccdRequest.getCaseDetails().getCaseId()));
             caseData.setEthosCaseReference(reference);
         }
+    }
+
+    private String generateOtherTypeDocumentName(List<DocumentTypeItem> docList) {
+        StringBuilder sb = new StringBuilder();
+        for (DocumentTypeItem doc : docList) {
+            if (doc.getValue().getTypeOfDocument().equals(SERVING_DOCUMENT_OTHER_TYPE)) {
+                sb.append("**<big>");
+                sb.append(doc.getValue().getUploadedDocument().getDocumentFilename());
+                sb.append("</big>**<br/>");
+                sb.append("<small>");
+                sb.append(doc.getValue().getShortDescription());
+                sb.append("</small><br/>");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/src/main/resources/exampleV4.json
+++ b/src/main/resources/exampleV4.json
@@ -1,0 +1,20 @@
+{
+  "case_details": {
+    "case_data": {
+      "servingDocumentCollection": [
+        {
+          "id": "5d21f579-aff5-402a-9d07-2af828200882",
+          "value": {
+            "typeOfDocument": "Another type of document",
+            "shortDescription": "Test description",
+            "uploadedDocument": {
+              "document_url": "test-document-url",
+              "document_filename": "test-filename.xlsx",
+              "document_binary_url": "test-document-binary-url"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
@@ -804,18 +804,15 @@ public class CaseActionsForCaseWorkerControllerTest {
     public void midServingDocumentOtherTypeNames() throws Exception {
         when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
 
-        CaseData data = new CaseData();
-        data.setOtherTypeDocumentName("**<big>test-filename.xlsx</big>**<br/><small>Test description</small><br/>");
-
+        String expectedDocumentName = "**<big>test-filename.xlsx</big>**<br/><small>Test description</small><br/>";
         mvc.perform(post(SERVING_DOCUMENT_OTHER_TYPE_NAMES_URL)
                         .content(requestContent4.toString())
                         .header("Authorization", AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value(data))
+                .andExpect(jsonPath("$.data.otherTypeDocumentName").value(expectedDocumentName))
                 .andExpect(jsonPath("$.errors", nullValue()))
                 .andExpect(jsonPath("$.warnings", nullValue()));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.ecm.common.model.helper.DefaultValues;
@@ -1632,6 +1631,16 @@ public class CaseActionsForCaseWorkerControllerTest {
 
         verify(clerkService, never()).initialiseClerkResponsible(isA(CaseData.class));
         verify(fileLocationSelectionService, never()).initialiseFileLocation(isA(CaseData.class));
+    }
+
+    @Test
+    public void midServingDocumentOtherTypeNamesForbidden() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(false);
+        mvc.perform(post(SERVING_DOCUMENT_OTHER_TYPE_NAMES_URL)
+                        .content(requestContent4.toString())
+                        .header("Authorization", AUTH_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
     }
 
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1852


### Change description ###
Following the submission of the ET1 form by the Claimant, the ET1 is vetted, and if accepted then the ET1 is required to be served to the Respondent (as per the Respondent details in the ET1 form).  A notification letter of ET1 serving is sent to the Respondent, together with a copy of ET3 form (by post) ** 

NB: This page will only come up if on the Upload letters page dropdown, the user selects another type of document which is not a known standard letter. Once the document has been uploaded, the admin/caseworker will need to select who the document will be sent to.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
