### PR TITLE
Fix venue text in dynamic hearings

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -224,5 +224,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
         <cve>CVE-2022-29885</cve>
     </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-security-rsa-1.0.10.RELEASE.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-rsa@.*$</packageUrl>
+        <cve>CVE-2022-22978</cve>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/DynamicListHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/DynamicListHelper.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.items.HearingTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.JurCodesTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.types.DateListedType;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -17,6 +18,9 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.RESPONDENT_TITLE;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.dynamiclists.DynamicJudgements.NO_HEARINGS;
 
 public class DynamicListHelper {
+
+    /** Format for the label property of a Hearing DynamicList item */
+    static final String DYNAMIC_HEARING_LABEL_FORMAT = "%s : %s - %s - %s";
 
     private DynamicListHelper() {
     }
@@ -66,14 +70,14 @@ public class DynamicListHelper {
         List<DynamicValueType> listItems = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(caseData.getHearingCollection())) {
             for (HearingTypeItem hearingTypeItem : caseData.getHearingCollection()) {
-                var hearingNumber = hearingTypeItem.getValue().getHearingNumber();
-                var dateListedType = hearingTypeItem.getValue().getHearingDateCollection().get(0).getValue();
-                var listedDate = dateListedType.getListedDate().substring(0, 10);
-                LocalDate date = LocalDate.parse(listedDate);
-                String hearingData = hearingNumber
-                        + " : " + hearingTypeItem.getValue().getHearingType()
-                        + " - " + hearingTypeItem.getValue().getHearingVenue()
-                        + " - " + date.format(DateTimeFormatter.ofPattern("dd MMM yyyy"));
+                var hearing = hearingTypeItem.getValue();
+                var hearingNumber = hearing.getHearingNumber();
+                var hearingType = hearing.getHearingType();
+                var venue = hearing.getHearingVenue() != null ? hearing.getHearingVenue().getSelectedLabel() : null;
+                var listedDate = getListedDate(hearing.getHearingDateCollection().get(0).getValue());
+
+                String hearingData = String.format(DYNAMIC_HEARING_LABEL_FORMAT, hearingNumber, hearingType, venue,
+                        listedDate);
                 listItems.add(getDynamicCodeLabel(hearingNumber, hearingData));
             }
         } else {
@@ -102,5 +106,11 @@ public class DynamicListHelper {
             }
         }
         return dynamicValue;
+    }
+
+    private static String getListedDate(DateListedType dateListedType) {
+        String listedDate = dateListedType.getListedDate().substring(0, 10);
+        LocalDate date = LocalDate.parse(listedDate);
+        return date.format(DateTimeFormatter.ofPattern("dd MMM yyyy"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/utils/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/utils/CaseDataBuilder.java
@@ -64,20 +64,33 @@ public class CaseDataBuilder {
     }
 
     public CaseDataBuilder withHearing(String hearingNumber, String hearingType, String judge) {
+        return withHearing(hearingNumber, hearingType, judge, null);
+    }
+
+    public CaseDataBuilder withHearing(String hearingNumber, String hearingType, String judge, String venue) {
         if (caseData.getHearingCollection() == null) {
             caseData.setHearingCollection(new ArrayList<>());
         }
 
+        HearingTypeItem hearingTypeItem = createHearing(hearingNumber, hearingType, judge, venue);
+        caseData.getHearingCollection().add(hearingTypeItem);
+
+        return this;
+    }
+
+    private HearingTypeItem createHearing(String hearingNumber, String hearingType, String judge, String venue) {
         var type = new HearingType();
         type.setHearingNumber(hearingNumber);
         type.setHearingType(hearingType);
         type.setJudge(new DynamicFixedListType(judge));
+        if (venue != null) {
+            type.setHearingVenue(DynamicFixedListType.of(DynamicValueType.create(venue, venue)));
+        }
 
         var hearingTypeItem = new HearingTypeItem();
         hearingTypeItem.setValue(type);
-        caseData.getHearingCollection().add(hearingTypeItem);
 
-        return this;
+        return hearingTypeItem;
     }
 
     public CaseDataBuilder withHearingSession(int hearingIndex, String number, String listedDate, String hearingStatus,
@@ -94,7 +107,7 @@ public class CaseDataBuilder {
         if (hearing.getValue().getHearingDateCollection() == null) {
             hearing.getValue().setHearingDateCollection(new ArrayList<>());
         }
-        var hearingDates = new ArrayList<DateListedTypeItem>();
+
         hearing.getValue().getHearingDateCollection().add(dateListedTypeItem);
 
         return this;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2036


### Change description ###
Starting the Judgment event fails if there is a hearing with a venue. This was because the DynamicListHelper wasn't handling the dynamic venue field correctly when it was creating a list of hearings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
