### PR TITLE
Update version of et-data-model to 1.0.31 and fix the broken tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: '2.13.3', ext: 'pom'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
     implementation group: 'com.github.hmcts', name: 'et-common', version:'0.0.38'
-    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.28'
+    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'1.0.31'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BulkCreationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BulkCreationServiceTest.java
@@ -322,7 +322,7 @@ public class BulkCreationServiceTest {
                 "lastModified=null, dataClassification=null), caseData=BulkData(bulkCaseTitle=null, multipleReference=null, multipleReferenceLinkMarkUp=null, feeGroupReference=111111, " +
                 "claimantSurname=Fernandez, respondentSurname=Mr Respondent, claimantRep=Mike Johnson, respondentRep=Juan Pedro, ethosCaseReference=null, " +
                 "clerkResponsible=null, fileLocation=null, jurCodesCollection=[JurCodesTypeItem(id=null, value=JurCodesType(juridictionCodesList=AB, " +
-                "judgmentOutcome=null, dateNotified=null, juridictionCodesSubList1=null))], fileLocationV2=null, feeGroupReferenceV2=null, claimantSurnameV2=null, " +
+                "judgmentOutcome=null, dateNotified=null, disposalDate=null, juridictionCodesSubList1=null))], fileLocationV2=null, feeGroupReferenceV2=null, claimantSurnameV2=null, " +
                 "respondentSurnameV2=null, multipleReferenceV2=null, clerkResponsibleV2=null, positionTypeV2=null, claimantRepV2=null, respondentRepV2=null, " +
                 "fileLocationGlasgow=null, fileLocationAberdeen=null, fileLocationDundee=null, fileLocationEdinburgh=null, managingOffice=null, subMultipleName=null, " +
                 "subMultipleRef=null, caseIdCollection=[CaseIdTypeItem(id=1111, value=CaseType(ethosCaseReference=1111))], searchCollection=null, " +
@@ -384,7 +384,7 @@ public class BulkCreationServiceTest {
                 "lastModified=null, dataClassification=null), caseData=BulkData(bulkCaseTitle=null, multipleReference=null, multipleReferenceLinkMarkUp=null, feeGroupReference=111111, " +
                 "claimantSurname=Fernandez, respondentSurname=Mr Respondent, claimantRep=Mike Johnson, respondentRep=Juan Pedro, ethosCaseReference=null, " +
                 "clerkResponsible=null, fileLocation=null, jurCodesCollection=[JurCodesTypeItem(id=null, value=JurCodesType(juridictionCodesList=AB, " +
-                "judgmentOutcome=null, dateNotified=null, juridictionCodesSubList1=null))], fileLocationV2=null, feeGroupReferenceV2=null, claimantSurnameV2=null, " +
+                "judgmentOutcome=null, dateNotified=null, disposalDate=null, juridictionCodesSubList1=null))], fileLocationV2=null, feeGroupReferenceV2=null, claimantSurnameV2=null, " +
                 "respondentSurnameV2=null, multipleReferenceV2=null, clerkResponsibleV2=null, positionTypeV2=null, claimantRepV2=null, respondentRepV2=null, " +
                 "fileLocationGlasgow=null, fileLocationAberdeen=null, fileLocationDundee=null, fileLocationEdinburgh=null, managingOffice=null, " +
                 "subMultipleName=null, subMultipleRef=null, caseIdCollection=[], searchCollection=[], midSearchCollection=null, " +


### PR DESCRIPTION
Et-data-model was updated to version 1.0.31 which broke two tests. Instead of waiting for RET-2033 to fix them (which includes lots of other changes), made this PR to fix it. Will allow me to continue working on RET-1845 which is blocked because of this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
