### PR TITLE
fixed exception when creating et3 document and title is not provided

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3ResponseHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3ResponseHelper.java
@@ -105,6 +105,11 @@ public class Et3ResponseHelper {
         data.setTitleMiss(UNCHECKED);
         data.setTitleMs(UNCHECKED);
         data.setTitleOther(UNCHECKED);
+
+        if (isNullOrEmpty(title)) {
+            return;
+        }
+
         switch  (title) {
             case "Mr":
                 data.setTitleMr(CHECKED);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2411

### Change description ###

Fixed crash when the optional preferredTitle field is not provided

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
