### PR TITLE
RET-2685: Prefilling 'is hearing already listed'

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationController.java
@@ -118,6 +118,7 @@ public class InitialConsiderationController {
         caseData.setEtInitialConsiderationJurisdictionCodes(
             initialConsiderationService.generateJurisdictionCodesHtml(caseData.getJurCodesCollection(),
                 ccdRequest.getCaseDetails().getCaseTypeId()));
+        initialConsiderationService.setIsHearingAlreadyListed(caseData);
 
         return getCallbackRespEntityNoErrors(caseData);
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationController.java
@@ -115,10 +115,12 @@ public class InitialConsiderationController {
             initialConsiderationService.getRespondentName(caseData.getRespondentCollection()));
         caseData.setEtInitialConsiderationHearing(
             initialConsiderationService.getHearingDetails(caseData.getHearingCollection()));
+
+        String caseTypeId = ccdRequest.getCaseDetails().getCaseTypeId();
+
         caseData.setEtInitialConsiderationJurisdictionCodes(
-            initialConsiderationService.generateJurisdictionCodesHtml(caseData.getJurCodesCollection(),
-                ccdRequest.getCaseDetails().getCaseTypeId()));
-        initialConsiderationService.setIsHearingAlreadyListed(caseData);
+            initialConsiderationService.generateJurisdictionCodesHtml(caseData.getJurCodesCollection(), caseTypeId));
+        initialConsiderationService.setIsHearingAlreadyListed(caseData, caseTypeId);
 
         return getCallbackRespEntityNoErrors(caseData);
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
@@ -200,7 +200,10 @@ public class InitialConsiderationService {
      * Sets etICHearingAlreadyListed if the case has a hearing listed.
      * @param caseData data about the current case
      */
-    public void setIsHearingAlreadyListed(CaseData caseData) {
+    public void setIsHearingAlreadyListed(CaseData caseData, String caseTypeId) {
+        if (ENGLANDWALES_CASE_TYPE_ID.equals(caseTypeId)) {
+            return;
+        }
         caseData.setEtICHearingAlreadyListed(HEARING_MISSING.equals(caseData.getEtInitialConsiderationHearing())
             ? NO : YES
         );

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
@@ -197,8 +197,8 @@ public class InitialConsiderationService {
     }
 
     /**
-     * Sets etICHearingAlreadyListed if there is a hearing listed.
-     * @param caseData data bout the current case
+     * Sets etICHearingAlreadyListed if the case has a hearing listed.
+     * @param caseData data about the current case
      */
     public void setIsHearingAlreadyListed(CaseData caseData) {
         caseData.setEtICHearingAlreadyListed(HEARING_MISSING.equals(caseData.getEtInitialConsiderationHearing())

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_ID;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.DocumentHelper.getHearingDuration;
@@ -193,6 +194,16 @@ public class InitialConsiderationService {
                 removeEtICHearingAlreadyListedNoValue(caseData);
             }
         }
+    }
+
+    /**
+     * Sets etICHearingAlreadyListed if there is a hearing listed.
+     * @param caseData data bout the current case
+     */
+    public void setIsHearingAlreadyListed(CaseData caseData) {
+        caseData.setEtICHearingAlreadyListed(HEARING_MISSING.equals(caseData.getEtInitialConsiderationHearing())
+            ? NO : YES
+        );
     }
 
     private void removeEtIcCanProceedYesValue(CaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
@@ -386,7 +386,7 @@ class InitialConsiderationServiceTest {
             + "|Duration | 60 Days|");
 
         initialConsiderationService.setIsHearingAlreadyListed(caseData, ENGLANDWALES_CASE_TYPE_ID);
-        assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(YES);
+        assertThat(caseData.getEtICHearingAlreadyListed()).isNull();
     }
 
     private List<JurCodesTypeItem> generateJurisdictionCodes() {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;
@@ -351,6 +352,30 @@ class InitialConsiderationServiceTest {
         assertThat(caseData.getEtICPostponeGiveDetails()).isNull();
         assertThat(caseData.getEtICConvertPreliminaryGiveDetails()).isNull();
         assertThat(caseData.getEtICConvertF2fGiveDetails()).isNull();
+    }
+
+    @Test
+    void setIsHearingAlreadyListed_shouldBeSetToNo_whenNoHearings() {
+        caseData.setEtInitialConsiderationHearing("|Hearing details | |\r\n"
+            + "|-------------|:------------|\r\n"
+            + "|Date | -|\r\n"
+            + "|Type | -|\r\n"
+            + "|Duration | -|");
+
+        initialConsiderationService.setIsHearingAlreadyListed(caseData);
+        assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(NO);
+    }
+
+    @Test
+    void setIsHearingAlreadyListed_shouldBeSetToYes_whenThereAreHearings() {
+        caseData.setEtInitialConsiderationHearing("|Hearing details | |\r\n"
+            + "|-------------|:------------|\r\n"
+            + "|Date | 16 May 2022|\r\n"
+            + "|Type | Hearing|\r\n"
+            + "|Duration | 60 Days|");
+
+        initialConsiderationService.setIsHearingAlreadyListed(caseData);
+        assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(YES);
     }
 
     private List<JurCodesTypeItem> generateJurisdictionCodes() {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
@@ -361,7 +361,7 @@ class InitialConsiderationServiceTest {
             + "|Type | -|\r\n"
             + "|Duration | -|");
 
-        initialConsiderationService.setIsHearingAlreadyListed(caseData);
+        initialConsiderationService.setIsHearingAlreadyListed(caseData, SCOTLAND_CASE_TYPE_ID);
         assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(NO);
     }
 
@@ -373,7 +373,19 @@ class InitialConsiderationServiceTest {
             + "|Type | Hearing|\r\n"
             + "|Duration | 60 Days|");
 
-        initialConsiderationService.setIsHearingAlreadyListed(caseData);
+        initialConsiderationService.setIsHearingAlreadyListed(caseData, SCOTLAND_CASE_TYPE_ID);
+        assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(YES);
+    }
+
+    @Test
+    void setIsHearingAlreadyListed_shouldIgnoreEntirely_whenCaseTypeIsEnglandWales() {
+        caseData.setEtInitialConsiderationHearing("|Hearing details | |\r\n"
+            + "|-------------|:------------|\r\n"
+            + "|Date | 16 May 2022|\r\n"
+            + "|Type | Hearing|\r\n"
+            + "|Duration | 60 Days|");
+
+        initialConsiderationService.setIsHearingAlreadyListed(caseData, ENGLANDWALES_CASE_TYPE_ID);
         assertThat(caseData.getEtICHearingAlreadyListed()).isEqualTo(YES);
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_TYPE_ID;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2685

### Change description ###

RET-2685: Prefilling 'is hearing already listed'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
