### PR TITLE
Ret 2983

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
@@ -105,18 +105,26 @@ public class InitialConsiderationService {
             .filter(hearingTypeItem -> hearingTypeItem != null && hearingTypeItem.getValue() != null)
             .map(HearingTypeItem::getValue)
             .filter(
-                hearing -> hearing.getHearingDateCollection() != null && !hearing.getHearingDateCollection().isEmpty())
-            .min(
-                Comparator.comparing(
+                hearing -> hearing.getHearingDateCollection() != null
+                    && !hearing.getHearingDateCollection().isEmpty())
+            .min(Comparator.comparing(
                     (HearingType hearing) ->
                         getEarliestHearingDateForListedHearings(hearing.getHearingDateCollection()).orElse(
                             LocalDate.now().plusYears(100))))
-            .map(hearing -> String.format(HEARING_DETAILS,
-                getEarliestHearingDateForListedHearings(hearing.getHearingDateCollection())
-                    .map(formatter::format).orElse(""),
-                hearing.getHearingType(),
                 getHearingDuration(hearing)))
+            .map(hearing -> getFormattedHearingDetails(hearing, formatter))
             .orElse(HEARING_MISSING);
+    }
+
+    private String getFormattedHearingDetails(HearingType hearing, DateTimeFormatter formatter) {
+        Optional<LocalDate> earliestHearingDate = getEarliestHearingDateForListedHearings(
+            hearing.getHearingDateCollection());
+        if (earliestHearingDate.isPresent()) {
+            return String.format(HEARING_DETAILS, earliestHearingDate.map(formatter::format).orElse(""),
+                hearing.getHearingType(), getHearingDuration(hearing));
+        } else {
+            return String.format(HEARING_DETAILS, "-", "-", "-");
+        }
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationService.java
@@ -111,7 +111,6 @@ public class InitialConsiderationService {
                     (HearingType hearing) ->
                         getEarliestHearingDateForListedHearings(hearing.getHearingDateCollection()).orElse(
                             LocalDate.now().plusYears(100))))
-                getHearingDuration(hearing)))
             .map(hearing -> getFormattedHearingDetails(hearing, formatter))
             .orElse(HEARING_MISSING);
     }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/InitialConsiderationServiceTest.java
@@ -140,6 +140,14 @@ class InitialConsiderationServiceTest {
         dateListed.setHearingTimingDuration("3.5 Hours");
     }
 
+    private void setFutureHearingDateWithSettledHearing(CaseData caseData) {
+        DateListedType dateListed = caseData.getHearingCollection().get(0).getValue().getHearingDateCollection()
+            .get(0).getValue();
+        dateListed.setHearingStatus("Settled");
+        dateListed.setListedDate(EARLIEST_FUTURE_HEARING_DATE.toString());
+        dateListed.setHearingTimingDuration("3.5 Hours");
+    }
+
     @Test
     void getEarliestHearingDate() {
         setFutureHearingDate(caseData);
@@ -162,6 +170,14 @@ class InitialConsiderationServiceTest {
     void getEarliestHearingDateWithEmptyHearingDatesCollection() {
         assertThat(initialConsiderationService.getEarliestHearingDateForListedHearings(new ArrayList<>()))
             .isEmpty();
+    }
+
+    @Test
+    void getHearingDetailsForSettledHearing() {
+        setFutureHearingDateWithSettledHearing(caseData);
+        String hearingDetails = initialConsiderationService.getHearingDetails(caseData.getHearingCollection());
+        assertThat(hearingDetails)
+            .isEqualTo(EXPECTED_HEARING_BLANK);
     }
 
     @Test
@@ -279,7 +295,6 @@ class InitialConsiderationServiceTest {
     @Test
     void clearHiddenValue_EtICCanProceed_No() {
         caseData.setEtICCanProceed(NO);
-
         caseData.setEtICHearingNotListedList(new ArrayList<>());
         caseData.setEtICHearingNotListedSeekComments(new EtICSeekComments());
         caseData.setEtICHearingNotListedListForPrelimHearing(new EtICListForPreliminaryHearing());
@@ -439,7 +454,6 @@ class InitialConsiderationServiceTest {
         JurCodesType code = new JurCodesType();
         code.setJuridictionCodesList(codeString);
         jurCodesTypeItem.setValue(code);
-
         return jurCodesTypeItem;
     }
 
@@ -451,7 +465,6 @@ class InitialConsiderationServiceTest {
     }
 
     private List<DateListedTypeItem> generateHearingDates() {
-
         return List.of(createDate("2022-07-15T10:00:00.000", null),
             createDate("2022-07-15T10:00:00.000", null),
             createDate("2022-05-20T10:00:00.000", null),


### PR DESCRIPTION
Correction for the display of empty hearing details including hearing with Settled status.

https://tools.hmcts.net/jira/browse/RET-2983


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
