### PR TITLE
RET-3078 implementation

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -433,7 +433,7 @@ public class CaseActionsForCaseWorkerController {
         }
 
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         log.info(EVENT_FIELDS_VALIDATION + errors);
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/dynamiclists/DynamicRespondentRepresentative.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/dynamiclists/DynamicRespondentRepresentative.java
@@ -21,11 +21,12 @@ public final class DynamicRespondentRepresentative {
         List<DynamicValueType> listItems = DynamicListHelper.createDynamicRespondentName(
                 caseData.getRespondentCollection());
         if (!listItems.isEmpty()) {
-            DynamicFixedListType dynamicFixedListType = new DynamicFixedListType();
-            dynamicFixedListType.setListItems(listItems);
+
             if (CollectionUtils.isNotEmpty(caseData.getRepCollection())) {
                 ListIterator<RepresentedTypeRItem> repItr = caseData.getRepCollection().listIterator();
                 while (repItr.hasNext()) {
+                    DynamicFixedListType dynamicFixedListType = new DynamicFixedListType();
+                    dynamicFixedListType.setListItems(listItems);
                     RepresentedTypeRItem respRepCollection = caseData.getRepCollection().get(repItr.nextIndex());
                     DynamicValueType dynamicValueType = new DynamicValueType();
                     if (respRepCollection.getValue().getDynamicRespRepName() == null) {
@@ -40,6 +41,8 @@ public final class DynamicRespondentRepresentative {
                     respRepCollection.getValue().getDynamicRespRepName().setValue(dynamicValueType);
                 }
             } else {
+                DynamicFixedListType dynamicFixedListType = new DynamicFixedListType();
+                dynamicFixedListType.setListItems(listItems);
                 RepresentedTypeR representedTypeR = RepresentedTypeR.builder()
                     .dynamicRespRepName(dynamicFixedListType).build();
                 RepresentedTypeRItem representedTypeRItem = new RepresentedTypeRItem();

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
@@ -156,7 +156,8 @@ public class EventValidationService {
 
     public List<String> validateET3ResponseFields(CaseData caseData) {
         List<String> errors = new ArrayList<>();
-        if (caseData.getRespondentCollection() != null && !caseData.getRespondentCollection().isEmpty()) {
+        if (caseData.getRespondentCollection() != null
+            && !caseData.getRespondentCollection().isEmpty()) {
             ListIterator<RespondentSumTypeItem> itr = caseData.getRespondentCollection().listIterator();
             while (itr.hasNext()) {
                 int index = itr.nextIndex() + 1;
@@ -168,35 +169,61 @@ public class EventValidationService {
         return errors;
     }
 
-    public List<String> validateRespRepNames(CaseData caseData) {
+    @SuppressWarnings("checkstyle:Indentation")
+    public List<String> validateAndSetRespRepNames(CaseData caseData) {
         List<String> errors = new ArrayList<>();
-        if (caseData.getRepCollection() != null && !caseData.getRepCollection().isEmpty()) {
-            ListIterator<RepresentedTypeRItem> repItr = caseData.getRepCollection().listIterator();
-            int index;
-            while (repItr.hasNext()) {
-                index = repItr.nextIndex() + 1;
-                String respRepName = repItr.next().getValue().getDynamicRespRepName().getValue().getLabel();
-                if (!isNullOrEmpty(respRepName)
-                        && CollectionUtils.isNotEmpty(caseData.getRespondentCollection())) {
-                    ListIterator<RespondentSumTypeItem> respItr = caseData.getRespondentCollection().listIterator();
-                    boolean validLink = false;
-                    while (respItr.hasNext()) {
-                        RespondentSumType respondentSumType = respItr.next().getValue();
-                        if (respRepName.equals(respondentSumType.getRespondentName())
-                                || respondentSumType.getResponseRespondentName() != null
-                                && respRepName.equals(respondentSumType.getResponseRespondentName())) {
-                            validLink = true;
-                            caseData.getRepCollection().get(index - 1).getValue().setRespRepName(respRepName);
-                            break;
-                        }
-                    }
-                    if (!validLink) {
-                        errors.add(RESP_REP_NAME_MISMATCH_ERROR_MESSAGE + " - " + index);
-                    }
-                }
+        if (CollectionUtils.isNotEmpty(caseData.getRespondentCollection())
+            && CollectionUtils.isNotEmpty(caseData.getRepCollection())) {
+            List<RepresentedTypeRItem> repCollection = caseData.getRepCollection();
+            List<RepresentedTypeRItem> updatedRepList = new ArrayList<>();
+            int repCollectionSize = caseData.getRepCollection().size();
+
+            //reverse update it - from the last to the first element by removing repetition
+            for (int index = repCollectionSize - 1;  index > -1; index--) {
+                String tempCollCurrentName = repCollection.get(index).getValue()
+                    .getDynamicRespRepName().getValue().getLabel();
+                if (isValidRespondentName(caseData, tempCollCurrentName)) {
+                    if (!repCollection.isEmpty()
+                        && updatedRepList.stream()
+                           .filter(r -> r.getValue().getDynamicRespRepName().getValue().getLabel()
+                               .equals(tempCollCurrentName)).collect(Collectors.toList()).isEmpty()) {
+                        repCollection.get(index).getValue().setRespRepName(tempCollCurrentName);
+                        updatedRepList.add(repCollection.get(index));
+                   }
+                } else {
+                    errors.add(RESP_REP_NAME_MISMATCH_ERROR_MESSAGE + " - " + tempCollCurrentName);
+                    return errors;
+               }
+            }
+
+            //clear the old rep collection
+            if (repCollectionSize > 0) {
+                caseData.getRepCollection().subList(0, repCollectionSize).clear();
+            }
+
+            //populate the rep collection with the new & updated rep entries and
+            //sort the collection by respondent name
+            updatedRepList.sort((o1, o2) -> o1.getValue().getRespRepName().compareTo(o2.getValue().getRespRepName()));
+            caseData.setRepCollection(updatedRepList);
+        }
+
+        return errors;
+    }
+
+    private boolean isValidRespondentName(CaseData caseData, String tempCollCurrentName) {
+        boolean isValidName = false;
+        if (CollectionUtils.isNotEmpty(caseData.getRespondentCollection())) {
+            var respRepNames = caseData.getRespondentCollection()
+                .stream()
+                .map(e -> e.getValue().getRespondentName())
+                .collect(Collectors.toList());
+
+            if (!respRepNames.isEmpty()) {
+                isValidName = respRepNames.contains(tempCollCurrentName);
             }
         }
-        return errors;
+
+        return isValidName;
     }
 
     public List<String> validateHearingNumber(CaseData caseData, CorrespondenceType correspondenceType,

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationService.java
@@ -169,7 +169,6 @@ public class EventValidationService {
         return errors;
     }
 
-    @SuppressWarnings("checkstyle:Indentation")
     public List<String> validateAndSetRespRepNames(CaseData caseData) {
         List<String> errors = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(caseData.getRespondentCollection())
@@ -185,15 +184,15 @@ public class EventValidationService {
                 if (isValidRespondentName(caseData, tempCollCurrentName)) {
                     if (!repCollection.isEmpty()
                         && updatedRepList.stream()
-                           .filter(r -> r.getValue().getDynamicRespRepName().getValue().getLabel()
-                               .equals(tempCollCurrentName)).collect(Collectors.toList()).isEmpty()) {
+                        .noneMatch(r -> r.getValue().getDynamicRespRepName().getValue().getLabel()
+                            .equals(tempCollCurrentName))) {
                         repCollection.get(index).getValue().setRespRepName(tempCollCurrentName);
                         updatedRepList.add(repCollection.get(index));
-                   }
+                    }
                 } else {
                     errors.add(RESP_REP_NAME_MISMATCH_ERROR_MESSAGE + " - " + tempCollCurrentName);
                     return errors;
-               }
+                }
             }
 
             //clear the old rep collection

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/Et1VettingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/Et1VettingServiceTest.java
@@ -87,6 +87,12 @@ class Et1VettingServiceTest {
         + "<h3>Respondent</h3><pre>Contact address &#09&#09 11 Small Street"
         + "<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 22 House<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Manchester<br>"
         + "&#09&#09&#09&#09&#09&#09&#09&#09&#09 M12 42R</pre><hr>";
+    private static final String EXPECTED_ADDRESSES_HTML_NO_WORK_ADDRESS = "<hr><h2>Listing details<hr><h3>Claimant</h3>"
+            + "<pre>Contact address &#09&#09 232 Petticoat Square<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 3 House<br>"
+            + "&#09&#09&#09&#09&#09&#09&#09&#09&#09 London<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 W10 4AG</pre>"
+            + "<hr><h3>Respondent</h3><pre>Contact address &#09&#09 11 Small Street"
+            + "<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 22 House<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Manchester<br>"
+            + "&#09&#09&#09&#09&#09&#09&#09&#09&#09 M12 42R</pre><hr>";
     private static final String EXPECTED_RESPONDENT1_ACAS_DETAILS = "<hr><h3>Respondent 1</h3><pre>Name "
         + "&#09&#09&#09&#09&#09&#09&nbsp; Antonio Vazquez<br><br>Contact address &#09&#09 11 Small Street<br>"
         + "&#09&#09&#09&#09&#09&#09&#09&#09&#09 22 House<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Manchester<br>"
@@ -411,6 +417,21 @@ class Et1VettingServiceTest {
         caseDetails.getCaseData().setClaimantWorkAddressQuestion("No");
         assertThat(et1VettingService.getAddressesHtml(caseDetails.getCaseData()))
             .isEqualTo(EXPECTED_ADDRESSES_HTML);
+    }
+
+    @Test
+    void testGettingHearingVenueAddressesHtmlQuestionYes() {
+        caseDetails.getCaseData().setManagingOffice("Manchester");
+        caseDetails.getCaseData().setClaimantWorkAddressQuestion("Yes");
+        assertThat(et1VettingService.getAddressesHtml(caseDetails.getCaseData()))
+                .isEqualTo(EXPECTED_ADDRESSES_HTML_NO_WORK_ADDRESS);
+    }
+
+    @Test
+    void testGettingHearingVenueAddressesHtmlQuestionNull() {
+        caseDetails.getCaseData().setManagingOffice("Manchester");
+        assertThat(et1VettingService.getAddressesHtml(caseDetails.getCaseData()))
+                .isEqualTo(EXPECTED_ADDRESSES_HTML_NO_WORK_ADDRESS);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/EventValidationServiceTest.java
@@ -290,7 +290,7 @@ class EventValidationServiceTest {
     void shouldValidateRespRepNamesWithEmptyRepCollection() {
         CaseData caseData = caseDetails1.getCaseData();
 
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         assertEquals(0, errors.size());
     }
@@ -299,7 +299,7 @@ class EventValidationServiceTest {
     void shouldValidateRespRepNamesWithMismatch() {
         CaseData caseData = caseDetails2.getCaseData();
 
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         assertEquals(1, errors.size());
     }
@@ -308,7 +308,7 @@ class EventValidationServiceTest {
     void shouldValidateRespRepNamesWithMatch() {
         CaseData caseData = caseDetails3.getCaseData();
 
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         assertEquals(0, errors.size());
     }
@@ -317,7 +317,7 @@ class EventValidationServiceTest {
     void shouldValidateRespRepNamesWithNullRepCollection() {
         CaseData caseData = caseDetails4.getCaseData();
 
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         assertEquals(0, errors.size());
     }
@@ -326,7 +326,7 @@ class EventValidationServiceTest {
     void shouldValidateRespRepNamesWithMatchResponseName() {
         CaseData caseData = caseDetails5.getCaseData();
 
-        List<String> errors = eventValidationService.validateRespRepNames(caseData);
+        List<String> errors = eventValidationService.validateAndSetRespRepNames(caseData);
 
         assertEquals(0, errors.size());
     }


### PR DESCRIPTION
Code change to implement RET-3078, i.e. a respondent is assigned only to one respondent representative. 

https://tools.hmcts.net/jira/browse/RET-3078


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
