### PR TITLE
Update nightly-dev to run ACAS tests from package.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ task codeceptFunctionalSauce(type: Exec, dependsOn: ':yarnInstall') {
 }
 
 task codeceptFunctionalNightly(type: Exec, dependsOn :'yarnInstall') {
-    commandLine './node_modules/codeceptjs/bin/codecept.js', 'run', '-c', './src/test/end-to-end/', '--grep', '@RET-ACAS', '--steps', '--reporter', 'mocha-multi'
+    commandLine './node_modules/codeceptjs/bin/codecept.js', 'run', '-c', './src/test/end-to-end/', '--grep', '@nightly', '--steps', '--reporter', 'mocha-multi'
 }
 
 task integration(type: Test) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "totp-generator": "0.0.13"
     },
     "scripts": {
-        "test:functional": "codeceptjs run --config ./src/test/end-to-end/codecept.conf.js --steps —-reporter mocha-multi",
+        "test:functional": "codeceptjs run -c ./src/test/end-to-end/codecept.conf.js --steps —-reporter mocha-multi --verbose --grep @RET-ACAS",
         "codeceptjs": "codeceptjs run --steps",
         "codeceptjs:headless": "HEADLESS=true codeceptjs run --steps"
     },

--- a/src/test/end-to-end/paths/verifyRespondentRepresentative.js
+++ b/src/test/end-to-end/paths/verifyRespondentRepresentative.js
@@ -11,7 +11,6 @@ Scenario('Verify Respondent Representative for a Representative without a myHMCT
     console.log("... case id =>" +caseId);
     await respondentRepresentative(I, eventNames.RESPONDENT_REPRESENTATIVE, false);
 
-}).tag('@RET-BAT')
-  .tag('@RET-ACAS')
+}).tag('@WIP')
   .tag('@nightly')
   .retry(testConfig.TestRetryScenarios);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2764


### Change description ###
Demo environment nightly pipeline e2e tests config changes for ACAS. Updated to use package.json instead of build.gradle files for functional tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
