### PR TITLE
Cleaned template IDs

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -18,44 +18,46 @@ tornado.url=https://eu.dws3.docmosis.com/api/render
 #tornado.url=http://localhost:9095/api/render
 tornado.accessKey=${TORNADO_ACCESS_KEY:}
 
-case_document_am.url =http://localhost:4455
+case_document_am.url=http://localhost:4455
 
-uk.gov.notify.api.key=${GOV_NOTIFY_API_KEY:someApiKey}
-referral.template.id=${REFERRAL_TEMPLATE_ID:12345}
-et1Serving.template.id=${ET1SERVING_TEMPLATE_ID:12345}
-et1Serving.respondent.template.id=${ET1SERVING_RESPONDENT_TEMPLATE_ID:12345}
-rejected.template.id=${REJECTED_TEMPLATE_ID:12345}
-et3Notification.template.id=${ET3_NOTIFICATION_TEMPLATE_ID:1234}
-et3Notification.template.myhmcts.id=${ET3_NOTIFICATION_TEMPLATE_MYHMCTS_ID:test}
-et3Notification.template.citizen.id=${ET3_NOTIFICATION_TEMPLATE_CITIZEN_ID:test}
+referral.template.id=6ee5ea2d-f912-4c17-93db-e782ad642110
+et1Serving.template.id=2d839d00-88f0-4136-a65e-364da046c6f8
+et1Serving.respondent.template.id=bf00082e-2709-472a-b0e8-11e53473741e
+rejected.template.id=2a2d1fc4-2e16-43b1-9328-f93a7e96a33d
+et3Notification.template.myhmcts.id=6983b7cf-a492-46da-8eaf-9751191eb736
+et3Notification.template.citizen.id=dd211d08-ba0a-4e9e-8502-31b4ed5515e9
 
-tse.admin.record-a-decision.notify.claimant.template.id=${TSE_ADMIN_RECORD_A_DECISION_CLAIMANT_TEMPLATE_ID:4d0fdc95-8f48-4a67-9713-3c8474044ad2}
-tse.admin.record-a-decision.notify.respondent.template.id=${TSE_ADMIN_RECORD_A_DECISION_RESPONDENT_TEMPLATE_ID:9cfc6f59-2c89-4fa3-a8f2-a4bdb3500146}
-tse.admin.reply.notify.claimant.template.id=${TSE_ADMIN_REPLY_CLAIMANT_TEMPLATE_ID:5baee9e9-e8c3-4518-a834-7f3bb336ca64}
-tse.admin.reply.notify.respondent.template.id=${TSE_ADMIN_REPLY_RESPONDENT_TEMPLATE_ID:ac13a3d3-3de6-4574-a52c-cc70e943dcac}
-tse.respondent.application.acknowledgement.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TEMPLATE_ID:91db4e44-ce62-44d2-af41-791341a067a6}
-tse.respondent.application.acknowledgement.type.c.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TYPE_C_TEMPLATE_ID:4740a6ed-7595-428d-a6f4-f12593bde82f}
-tse.respondent.application.notify.claimant.template.id=${TSE_RESPONDENT_TO_CLAIMANT_TEMPLATE_ID:c815d073-ee7e-4a22-b119-e313e4e4023e}
-tse.respondent.respond.acknowledgement.rule92no.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_NO_TEMPLATE_ID:84e64ff7-7c27-42b6-a7fa-ea29dd712223}
-tse.respondent.respond.acknowledgement.rule92yes.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_YES_TEMPLATE_ID:580028e7-d9ff-49de-96c2-dc9595572ebb}
-tse.respondent.respond.notify.claimant.template.id=${TSE_RESPONDENT_RESPONSE_TEMPLATE_ID:b1249c5c-9d7c-4e39-bb81-9e95fa058ed3}
+tse.admin.record-a-decision.notify.claimant.template.id=4d0fdc95-8f48-4a67-9713-3c8474044ad2
+tse.admin.record-a-decision.notify.respondent.template.id=9cfc6f59-2c89-4fa3-a8f2-a4bdb3500146
+tse.admin.reply.notify.claimant.template.id=5baee9e9-e8c3-4518-a834-7f3bb336ca64
+tse.admin.reply.notify.respondent.template.id=ac13a3d3-3de6-4574-a52c-cc70e943dcac
+tse.respondent.application.acknowledgement.template.id=91db4e44-ce62-44d2-af41-791341a067a6
+tse.respondent.application.acknowledgement.type.c.template.id=4740a6ed-7595-428d-a6f4-f12593bde82f
+tse.respondent.application.notify.claimant.template.id=c815d073-ee7e-4a22-b119-e313e4e4023e
+tse.respondent.respond.acknowledgement.rule92no.template.id=84e64ff7-7c27-42b6-a7fa-ea29dd712223
+tse.respondent.respond.acknowledgement.rule92yes.template.id=580028e7-d9ff-49de-96c2-dc9595572ebb
+tse.respondent.respond.notify.claimant.template.id=b1249c5c-9d7c-4e39-bb81-9e95fa058ed3
+tse.respondent.application.tribunal.template.id=42984f86-cbf3-4845-a0bd-2b0ea443e99d
 
-pse.respondent.acknowledgement.yes.template.id=${PSE_RESPONDENT_ACKNOWLEDGEMENT_YES_TEMPLATE_ID:c9a03bc6-2659-4678-8b3b-68b1f5d7524a}
-pse.respondent.acknowledgement.no.template.id=${PSE_RESPONDENT_ACKNOWLEDGEMENT_NO_TEMPLATE_ID:c1113a7f-5f6b-4563-9cc0-8b5c10d36822}
-pse.respondent.notification.claimant.template.id=${PSE_RESPONDENT_NOTIFICATION_CLAIMANT_TEMPLATE_ID:9cf5e28a-7699-42e6-999f-fad87e55c454}
-pse.respondent.notification.admin.template.id=${PSE_RESPONDENT_NOTIFICATION_ADMIN_TEMPLATE_ID:b1f19de4-c8dc-43b0-9493-68a130aff0d2}
+pse.respondent.acknowledgement.yes.template.id=c9a03bc6-2659-4678-8b3b-68b1f5d7524a
+pse.respondent.acknowledgement.no.template.id=c1113a7f-5f6b-4563-9cc0-8b5c10d36822
+pse.respondent.notification.claimant.template.id=9cf5e28a-7699-42e6-999f-fad87e55c454
+pse.respondent.notification.admin.template.id=b1f19de4-c8dc-43b0-9493-68a130aff0d2
+
+nocNotification.template.respondent.id=a3539d79-65c0-491c-b578-b58cf321f83e
+nocNotification.template.claimant.id=3d0c5784-0055-4863-9c03-7d37d9b2ad8d
+nocNotification.template.previousrespondentsolicitor.id=fe52b39f-852c-43ca-a42a-b9a27c43b130
+nocNotification.template.newrespondentsolicitor.id=8fe52f24-40b2-4986-8f86-4dd1af311cbd
+nocNotification.template.tribunal.id=1d5efcbd-1971-4ebe-bfe8-72ba36b5abac
+
+sendNotification.template.id=d7c7a3f5-af31-4393-963b-26c2497a0132
+respondNotification.noResponseTemplate.id=16f12e57-7cb0-49d1-9000-d23a73c37fd3
 
 queue.create-updates.queue-name = ${CREATE_UPDATES_QUEUE_NAME:create-updates}
 queue.create-updates.send.connection-string = ${CREATE_UPDATES_QUEUE_SEND_CONNECTION_STRING}
 
-
 assign_case_access_api_url=${AAC_URL:http://localhost:4454}
 apply_noc_access_api_assignments_path=/noc/apply-decision
 
-sendNotification.template.id=${SEND_NOTIFICATION_TEMPLATE_ID:d7c7a3f5-af31-4393-963b-26c2497a0132}
-respondNotification.noResponseTemplate.id=${RESPOND_NOTIFICATION_NO_RESPONSE_TEMPLATE_ID:16f12e57-7cb0-49d1-9000-d23a73c37fd3}
-
 url.exui.case-details=${EXUI_CASE_DETAILS_URL:http://localhost:3455/cases/case-details/}
 url.citizen.case-details=${CITIZEN_CASE_DETAILS_URL:http://localhost:3001/citizen-hub/}
-
-tse.respondent.application.tribunal.template.id=${TSE_NEW_APPLICATION_ADMIN_TEMPLATE_ID:42984f86-cbf3-4845-a0bd-2b0ea443e99d}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ server.port=8081
 feign.httpclient.enabled = true
 
 tornado.url=${TORNADO_URL:http://localhost:8090/rs/render}
-tornado.accessKey=${TORNADO_ACCESS_KEY:}
+tornado.accessKey=${TORNADO_ACCESS_KEY}
 
 azure.application-insights.instrumentation-key: ${APP_INSIGHTS_KEY:00000000-0000-0000-0000-000000000000}
 
@@ -45,14 +45,6 @@ ccd_gateway_base_url = ${CCD_GATEWAY_BASE_URL:http://127.0.0.1:3453}
 case_document_am.url = ${CASE_DOCUMENT_AM_URL:http://ccd-case-document-am-api:4455}
 feature.secure-doc-store.enabled = false
 
-uk.gov.notify.api.key=${GOV_NOTIFY_API_KEY}
-referral.template.id=${REFERRAL_TEMPLATE_ID}
-et1Serving.template.id=${ET1SERVING_TEMPLATE_ID}
-et1Serving.respondent.template.id=${ET1SERVING_RESPONDENT_TEMPLATE_ID}
-rejected.template.id=${REJECTED_TEMPLATE_ID}
-et3Notification.template.myhmcts.id=${ET3_NOTIFICATION_TEMPLATE_MYHMCTS_ID}
-et3Notification.template.citizen.id=${ET3_NOTIFICATION_TEMPLATE_CITIZEN_ID}
-
 # QUEUES
 queue.create-updates.send.connection-string = ${CREATE_UPDATES_QUEUE_SEND_CONNECTION_STRING}
 queue.create-updates.queue-name = create-updates
@@ -61,16 +53,25 @@ springdoc.packagesToScan=uk.gov.hmcts.ethos.replacement.docmosis.controllers
 springdoc.pathsToMatch=/**
 springdoc.pre-loading-enabled=true
 
-tse.admin.record-a-decision.notify.claimant.template.id=${TSE_ADMIN_RECORD_A_DECISION_CLAIMANT_TEMPLATE_ID:test}
-tse.admin.record-a-decision.notify.respondent.template.id=${TSE_ADMIN_RECORD_A_DECISION_RESPONDENT_TEMPLATE_ID:test}
-tse.admin.reply.notify.claimant.template.id=${TSE_ADMIN_REPLY_CLAIMANT_TEMPLATE_ID:test}
-tse.admin.reply.notify.respondent.template.id=${TSE_ADMIN_REPLY_RESPONDENT_TEMPLATE_ID:test}
-tse.respondent.application.acknowledgement.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TEMPLATE_ID:test}
-tse.respondent.application.acknowledgement.type.c.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TYPE_C_TEMPLATE_ID:test}
-tse.respondent.application.notify.claimant.template.id=${TSE_RESPONDENT_TO_CLAIMANT_TEMPLATE_ID:test}
-tse.respondent.respond.acknowledgement.rule92no.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_NO_TEMPLATE_ID:test}
-tse.respondent.respond.acknowledgement.rule92yes.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_YES_TEMPLATE_ID:test}
-tse.respondent.respond.notify.claimant.template.id=${TSE_RESPONDENT_RESPONSE_TEMPLATE_ID:test}
+uk.gov.notify.api.key=${GOV_NOTIFY_API_KEY}
+
+referral.template.id=${REFERRAL_TEMPLATE_ID}
+et1Serving.template.id=${ET1SERVING_TEMPLATE_ID}
+et1Serving.respondent.template.id=${ET1SERVING_RESPONDENT_TEMPLATE_ID}
+rejected.template.id=${REJECTED_TEMPLATE_ID}
+et3Notification.template.myhmcts.id=${ET3_NOTIFICATION_TEMPLATE_MYHMCTS_ID}
+et3Notification.template.citizen.id=${ET3_NOTIFICATION_TEMPLATE_CITIZEN_ID}
+
+tse.admin.record-a-decision.notify.claimant.template.id=${TSE_ADMIN_RECORD_A_DECISION_CLAIMANT_TEMPLATE_ID}
+tse.admin.record-a-decision.notify.respondent.template.id=${TSE_ADMIN_RECORD_A_DECISION_RESPONDENT_TEMPLATE_ID}
+tse.admin.reply.notify.claimant.template.id=${TSE_ADMIN_REPLY_CLAIMANT_TEMPLATE_ID}
+tse.admin.reply.notify.respondent.template.id=${TSE_ADMIN_REPLY_RESPONDENT_TEMPLATE_ID}
+tse.respondent.application.acknowledgement.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TEMPLATE_ID}
+tse.respondent.application.acknowledgement.type.c.template.id=${TSE_RESPONDENT_TO_RESPONDENT_TYPE_C_TEMPLATE_ID}
+tse.respondent.application.notify.claimant.template.id=${TSE_RESPONDENT_TO_CLAIMANT_TEMPLATE_ID}
+tse.respondent.respond.acknowledgement.rule92no.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_NO_TEMPLATE_ID}
+tse.respondent.respond.acknowledgement.rule92yes.template.id=${TSE_RESPONDENT_ACKNOWLEDGEMENT_YES_TEMPLATE_ID}
+tse.respondent.respond.notify.claimant.template.id=${TSE_RESPONDENT_RESPONSE_TEMPLATE_ID}
 tse.respondent.application.tribunal.template.id=${TSE_NEW_APPLICATION_ADMIN_TEMPLATE_ID}
 
 pse.respondent.acknowledgement.yes.template.id=${PSE_RESPONDENT_ACKNOWLEDGEMENT_YES_TEMPLATE_ID}
@@ -78,20 +79,20 @@ pse.respondent.acknowledgement.no.template.id=${PSE_RESPONDENT_ACKNOWLEDGEMENT_N
 pse.respondent.notification.claimant.template.id=${PSE_RESPONDENT_NOTIFICATION_CLAIMANT_TEMPLATE_ID}
 pse.respondent.notification.admin.template.id=${PSE_RESPONDENT_NOTIFICATION_ADMIN_TEMPLATE_ID}
 
-etcos.system.username=${ET_COS_SYSTEM_USER}
-etcos.system.password=${ET_COS_SYSTEM_USER_PASSWORD}
-
-nocNotification.template.respondent.id=${NOC_NOTIFICATION_TEMPLATE_RESPONDENT_ID:test}
-nocNotification.template.claimant.id=${NOC_NOTIFICATION_TEMPLATE_CLAIMANT_ID:test}
-nocNotification.template.previousrespondentsolicitor.id=${NOC_NOTIFICATION_TEMPLATE_OLD_REP_ID:test}
-nocNotification.template.newrespondentsolicitor.id=${NOC_NOTIFICATION_TEMPLATE_NEW_REP_ID:test}
-nocNotification.template.tribunal.id=${NOC_NOTIFICATION_TEMPLATE_TRIBUNAL_ID:test}
-
-assign_case_access_api_url=${AAC_URL:http://localhost:4454}
-apply_noc_access_api_assignments_path=/noc/apply-decision
+nocNotification.template.respondent.id=${NOC_NOTIFICATION_TEMPLATE_RESPONDENT_ID}
+nocNotification.template.claimant.id=${NOC_NOTIFICATION_TEMPLATE_CLAIMANT_ID}
+nocNotification.template.previousrespondentsolicitor.id=${NOC_NOTIFICATION_TEMPLATE_OLD_REP_ID}
+nocNotification.template.newrespondentsolicitor.id=${NOC_NOTIFICATION_TEMPLATE_NEW_REP_ID}
+nocNotification.template.tribunal.id=${NOC_NOTIFICATION_TEMPLATE_TRIBUNAL_ID}
 
 sendNotification.template.id=${SEND_NOTIFICATION_TEMPLATE_ID}
 respondNotification.noResponseTemplate.id=${RESPOND_NOTIFICATION_NO_RESPONSE_TEMPLATE_ID}
+
+etcos.system.username=${ET_COS_SYSTEM_USER}
+etcos.system.password=${ET_COS_SYSTEM_USER_PASSWORD}
+
+assign_case_access_api_url=${AAC_URL:http://localhost:4454}
+apply_noc_access_api_assignments_path=/noc/apply-decision
 
 url.exui.case-details=${EXUI_CASE_DETAILS_URL}
 url.citizen.case-details=${CITIZEN_CASE_DETAILS_URL}


### PR DESCRIPTION
Added all template ids to the dev.properties file so they don't depend on env variables.
Removed default values from application.properties
Removed old unreferenced dev properties and added new missing ones.
Enforce devs to have tornado and gov.notify access keys in env variables.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
