### PR TITLE
RET-3485 Respond to a Notification fails when claimant email address is missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -442,7 +442,7 @@ bootWithCCD {
     //environment 'SERVICEBUS_FAKE', 'true'
 }
 
-pmdMain.maxFailures = 699
-pmdTest.maxFailures = 717
+pmdMain.maxFailures = 698
+pmdTest.maxFailures = 268
 
-pmdTest.ruleSets = ["config/pmd/rulesetTest.xml"]
+pmdTest.ruleSetFiles = files("config/pmd/rulesetTest.xml")

--- a/build.gradle
+++ b/build.gradle
@@ -443,6 +443,6 @@ bootWithCCD {
 }
 
 pmdMain.maxFailures = 699
-pmdTest.maxFailures = 716
+pmdTest.maxFailures = 717
 
 pmdTest.ruleSets = ["config/pmd/rulesetTest.xml"]

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/RespondNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/RespondNotificationService.java
@@ -226,9 +226,11 @@ public class RespondNotificationService {
             templateId = responseTemplateId;
         }
 
+        String claimantEmail = caseData.getClaimantType().getClaimantEmailAddress();
+
         String sendNotificationTitle = sendNotificationType.getSendNotificationTitle();
-        if (!RESPONDENT_ONLY.equals(caseData.getRespondNotificationPartyToNotify())) {
-            emailService.sendEmail(templateId, caseData.getClaimantType().getClaimantEmailAddress(),
+        if (!RESPONDENT_ONLY.equals(caseData.getRespondNotificationPartyToNotify()) && !isNullOrEmpty(claimantEmail)) {
+            emailService.sendEmail(templateId, claimantEmail,
                 buildPersonalisation(caseDetails, citizenUrl, sendNotificationTitle));
         }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/RespondNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/RespondNotificationServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -385,6 +386,23 @@ class RespondNotificationServiceTest {
     }
 
     @Test
+    void sendNotifyEmailsNoResponseClaimantOnlyMissingEmail() {
+        setUpNotifyEmail();
+
+        caseData.setRespondNotificationPartyToNotify(CLAIMANT_ONLY);
+        caseData.setRespondNotificationResponseRequired(NO);
+        caseData.getClaimantType().setClaimantEmailAddress(null);
+        caseDetails.setCaseData(caseData);
+        SendNotificationType sendNotification = SendNotificationType.builder().sendNotificationTitle("TEST").build();
+        respondNotificationService.sendNotifyEmails(caseDetails, sendNotification);
+        verify(emailService, times(0)).sendEmail(eq("noResponseTemplateId"),
+            eq(CLAIMANT_EMAIL), any());
+        verify(emailService, times(0)).sendEmail(eq("noResponseTemplateId"),
+            eq(RESPONDENT_EMAIL), any());
+
+    }
+
+    @Test
     void sendNotifyEmailsResponseRequiredRespondentOnly() {
         setUpNotifyEmail();
 
@@ -396,6 +414,23 @@ class RespondNotificationServiceTest {
         verify(emailService, times(0)).sendEmail(eq("responseTemplateId"),
             eq(CLAIMANT_EMAIL), any());
         verify(emailService, times(1)).sendEmail(eq("responseTemplateId"),
+            eq(RESPONDENT_EMAIL), any());
+
+    }
+
+    @Test
+    void sendNotifyEmailsResponseRequiredRespondentOnlyMissingEmail() {
+        setUpNotifyEmail();
+
+        caseData.setRespondNotificationPartyToNotify(RESPONDENT_ONLY);
+        caseData.setRespondNotificationResponseRequired(YES);
+        caseData.getRespondentCollection().get(0).getValue().setRespondentEmail(null);
+        caseDetails.setCaseData(caseData);
+        SendNotificationType sendNotification = SendNotificationType.builder().sendNotificationTitle("TEST").build();
+        respondNotificationService.sendNotifyEmails(caseDetails, sendNotification);
+        verify(emailService, times(0)).sendEmail(eq("responseTemplateId"),
+            eq(CLAIMANT_EMAIL), any());
+        verify(emailService, times(0)).sendEmail(eq("responseTemplateId"),
             eq(RESPONDENT_EMAIL), any());
 
     }


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-3485


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
