### PR TITLE
RET-3106: Hotfix for when hearings collection is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BundlesRespondentService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BundlesRespondentService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.ethos.replacement.docmosis.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicValueType;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
@@ -34,6 +35,9 @@ public class BundlesRespondentService {
      * Populates select hearing field with available hearings.
      */
     public void populateSelectHearings(CaseData caseData) {
+        if (CollectionUtils.isEmpty(caseData.getHearingCollection())) {
+            return;
+        }
         DynamicFixedListType listType = DynamicFixedListType.from(caseData.getHearingCollection().stream()
                 .map(this::createValueType)
                 .collect(Collectors.toList())

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BundlesRespondentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/BundlesRespondentServiceTest.java
@@ -79,4 +79,12 @@ class BundlesRespondentServiceTest {
         assertThat(actual.get(0).getLabel(), is("1 Hearing - Edinburgh - 16 May 2069"));
         assertThat(actual.get(1).getLabel(), is("2 Costs Hearing - Aberdeen - 16 May 2069"));
     }
+
+    @Test
+    void populateSelectHearings_doesNothingWhenNoHearings() {
+        scotlandCaseData.setHearingCollection(null);
+        bundlesRespondentService.populateSelectHearings(scotlandCaseData);
+
+        assertNull(scotlandCaseData.getBundlesRespondentSelectHearing());
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3106

### Change description ###

Hotfix for when hearings collection is null

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
