### PR TITLE
RET-3279: Adjusted NoC claimant email template away from placeholder url and linking to a specific case id

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/NoticeOfChangeController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/NoticeOfChangeController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.et.common.model.ccd.CCDCallbackResponse;
 import uk.gov.hmcts.et.common.model.ccd.CallbackRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.types.ChangeOrganisationRequest;
 import uk.gov.hmcts.et.common.model.generic.GenericCallbackResponse;
 import uk.gov.hmcts.ethos.replacement.docmosis.exceptions.CcdInputOutputException;
@@ -78,7 +79,7 @@ public class NoticeOfChangeController {
 
         try {
             nocNotificationService.sendNotificationOfChangeEmails(callbackRequest,
-                    callbackRequest.getCaseDetails().getCaseData());
+                    callbackRequest.getCaseDetails());
         } catch (Exception exception) {
             log.error(exception.getMessage(), exception);
         }
@@ -116,12 +117,12 @@ public class NoticeOfChangeController {
         GenericCallbackResponse callbackResponse = new GenericCallbackResponse();
 
         if (APPLY_NOC_DECISION.equals(callbackRequest.getEventId())) {
-            CaseData caseData = callbackRequest.getCaseDetails().getCaseData();
+            CaseDetails caseDetails = callbackRequest.getCaseDetails();
+            CaseData caseData = caseDetails.getCaseData();
 
             //send emails here
             try {
-                nocNotificationService.sendNotificationOfChangeEmails(callbackRequest,
-                    caseData);
+                nocNotificationService.sendNotificationOfChangeEmails(callbackRequest, caseDetails);
             } catch (Exception exception) {
                 log.error(exception.getMessage(), exception);
             }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.hmcts.et.common.model.ccd.CallbackRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.SolicitorRole;
@@ -98,11 +99,12 @@ public final class NocNotificationHelper {
 
     }
 
-    public static Map<String, String> buildPersonalisationWithPartyName(CaseData caseData, String partyName) {
+    public static Map<String, String> buildPersonalisationWithPartyName(CaseDetails caseDetails, String partyName) {
         Map<String, String> personalisation = new ConcurrentHashMap<>();
 
-        addCommonValues(caseData, personalisation);
+        addCommonValues(caseDetails.getCaseData(), personalisation);
         personalisation.put("party_name", partyName);
+        personalisation.put("ccdId", caseDetails.getCaseId());
 
         return personalisation;
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.et.common.model.ccd.CallbackRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocNotificationHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocRespondentHelper;
@@ -33,8 +34,9 @@ public class NocNotificationService {
     @Value("${nocNotification.template.tribunal.id}")
     private String tribunalTemplateId;
 
-    public void sendNotificationOfChangeEmails(CallbackRequest callbackRequest, CaseData caseData) {
+    public void sendNotificationOfChangeEmails(CallbackRequest callbackRequest, CaseDetails caseDetails) {
         String partyName = NocNotificationHelper.getRespondentNameForNewSolicitor(callbackRequest);
+        CaseData caseData = caseDetails.getCaseData();
         String claimantEmail = NotificationHelper.buildMapForClaimant(caseData, "").get("emailAddress");
         if (isNullOrEmpty(claimantEmail)) {
             log.warn("missing claimantEmail");
@@ -42,7 +44,7 @@ public class NocNotificationService {
             emailService.sendEmail(
                 claimantTemplateId,
                 claimantEmail,
-                NocNotificationHelper.buildPersonalisationWithPartyName(caseData, partyName)
+                NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, partyName)
             );
         }
 
@@ -64,7 +66,7 @@ public class NocNotificationService {
             emailService.sendEmail(
                 newRespondentSolicitorTemplateId,
                 newSolicitorEmail,
-                NocNotificationHelper.buildPersonalisationWithPartyName(caseData, partyName)
+                NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, partyName)
             );
         }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
@@ -21,6 +21,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 @ExtendWith(SpringExtension.class)
 class NocNotificationHelperTest {
     private CaseData caseData;
+    private CaseDetails caseDetails;
 
     private RespondentSumType respondentSumType;
 
@@ -38,7 +39,7 @@ class NocNotificationHelperTest {
                 .organisationID("2")
                 .organisationName("Old Organisation").build();
 
-        CaseDetails caseDetails = CaseDataBuilder.builder()
+        caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("12345/6789")
             .withClaimantType("claimant@unrepresented.com")
             .withRepresentativeClaimantType("Claimant Rep", "claimant@represented.com")
@@ -72,8 +73,8 @@ class NocNotificationHelperTest {
     @Test
     void testbuildClaimantPersonalisation() {
         Map<String, String> claimantPersonalisation =
-            NocNotificationHelper.buildPersonalisationWithPartyName(caseData, "test_party");
-        assertThat(claimantPersonalisation.size(), is(4));
+            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party");
+        assertThat(claimantPersonalisation.size(), is(5));
         for (String value : claimantPersonalisation.values()) {
             assertThat(value, notNullValue());
         }
@@ -92,8 +93,8 @@ class NocNotificationHelperTest {
     @Test
     void testBuildNewRespondentSolicitorPersonalisation() {
         Map<String, String> claimantPersonalisation =
-            NocNotificationHelper.buildPersonalisationWithPartyName(caseData, "test_party");
-        assertThat(claimantPersonalisation.size(), is(4));
+            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party");
+        assertThat(claimantPersonalisation.size(), is(5));
         for (String value : claimantPersonalisation.values()) {
             assertThat(value, notNullValue());
         }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
@@ -30,6 +30,7 @@ class NocNotificationServiceTest {
     @Mock
     private EmailService emailService;
     private CaseData caseData;
+    private CaseDetails caseDetails;
     private CaseDetails caseDetailsBefore;
     private CallbackRequest callbackRequest;
 
@@ -45,7 +46,7 @@ class NocNotificationServiceTest {
             .organisationID("2")
             .organisationName("Old Organisation").build();
 
-        CaseDetails caseDetails = CaseDataBuilder.builder()
+        caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("12345/6789")
             .withClaimantType("claimant@unrepresented.com")
             .withRepresentativeClaimantType("Claimant Rep", "claimant@represented.com")
@@ -110,7 +111,7 @@ class NocNotificationServiceTest {
         respondentSumType.setRespondentName("Respondent");
         respondentSumType.setRespondentEmail("res@rep.com");
         when(nocRespondentHelper.getRespondent(any(), any())).thenReturn(respondentSumType);
-        nocNotificationService.sendNotificationOfChangeEmails(callbackRequest, caseData);
+        nocNotificationService.sendNotificationOfChangeEmails(callbackRequest, caseDetails);
         // Claimant
         verify(emailService, times(1)).sendEmail(any(), eq("claimant@represented.com"), any());
         // Previous respondent
@@ -139,7 +140,7 @@ class NocNotificationServiceTest {
 
         when(nocRespondentHelper.getRespondent(any(), any())).thenReturn(respondentSumType);
 
-        nocNotificationService.sendNotificationOfChangeEmails(callbackRequest, caseData);
+        nocNotificationService.sendNotificationOfChangeEmails(callbackRequest, caseDetails);
         verify(emailService, times(0)).sendEmail(any(), any(), any());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3279

### Change description ###

Adjusted NoC claimant email template away from placeholder url and linking to a specific case id

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
