### PR TITLE
RET-3279: Adjusted NoC claimant email template away from placeholder url and linking to a specific case id

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/NoticeOfChangeController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/NoticeOfChangeController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.et.common.model.ccd.CCDCallbackResponse;
 import uk.gov.hmcts.et.common.model.ccd.CallbackRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.generic.GenericCallbackResponse;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CcdCaseAssignment;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.NocNotificationService;
@@ -75,12 +76,13 @@ public class NoticeOfChangeController {
         GenericCallbackResponse callbackResponse = new GenericCallbackResponse();
 
         if (APPLY_NOC_DECISION.equals(callbackRequest.getEventId())) {
-            CaseData caseData = callbackRequest.getCaseDetails().getCaseData();
+            CaseDetails caseDetails = callbackRequest.getCaseDetails();
+            CaseData caseData = caseDetails.getCaseData();
 
             //send emails here
             try {
                 nocNotificationService.sendNotificationOfChangeEmails(
-                        callbackRequest.getCaseDetailsBefore().getCaseData(), caseData,
+                        callbackRequest.getCaseDetailsBefore(), caseDetails,
                         callbackRequest.getCaseDetailsBefore().getCaseData().getChangeOrganisationRequestField());
             } catch (Exception exception) {
                 log.error(exception.getMessage(), exception);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.ethos.replacement.docmosis.helpers;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.items.RepresentedTypeRItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.ChangeOrganisationRequest;
@@ -97,11 +98,12 @@ public final class NocNotificationHelper {
 
     }
 
-    public static Map<String, String> buildPersonalisationWithPartyName(CaseData caseData, String partyName) {
+    public static Map<String, String> buildPersonalisationWithPartyName(CaseDetails caseDetails, String partyName) {
         Map<String, String> personalisation = new ConcurrentHashMap<>();
 
-        addCommonValues(caseData, personalisation);
+        addCommonValues(caseDetails.getCaseData(), personalisation);
         personalisation.put("party_name", partyName);
+        personalisation.put("ccdId", caseDetails.getCaseId());
 
         return personalisation;
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.types.ChangeOrganisationRequest;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocNotificationHelper;
@@ -33,9 +34,11 @@ public class NocNotificationService {
     @Value("${nocNotification.template.tribunal.id}")
     private String tribunalTemplateId;
 
-    public void sendNotificationOfChangeEmails(CaseData caseDataPrevious, CaseData caseDataNew,
+    public void sendNotificationOfChangeEmails(CaseDetails caseDetailsPrevious, CaseDetails caseDetailsNew,
                                                ChangeOrganisationRequest changeRequest) {
+        CaseData caseDataNew = caseDetailsNew.getCaseData();
         String partyName = NocNotificationHelper.getRespondentNameForNewSolicitor(changeRequest, caseDataNew);
+        CaseData caseDataPrevious = caseDetailsPrevious.getCaseData();
         String claimantEmail = NotificationHelper.buildMapForClaimant(caseDataPrevious, "").get("emailAddress");
         if (isNullOrEmpty(claimantEmail)) {
             log.warn("missing claimantEmail");
@@ -43,7 +46,7 @@ public class NocNotificationService {
             emailService.sendEmail(
                 claimantTemplateId,
                 claimantEmail,
-                NocNotificationHelper.buildPersonalisationWithPartyName(caseDataPrevious, partyName)
+                NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsPrevious, partyName)
             );
         }
         String oldSolicitorEmail = NocNotificationHelper
@@ -64,7 +67,7 @@ public class NocNotificationService {
             emailService.sendEmail(
                 newRespondentSolicitorTemplateId,
                 newSolicitorEmail,
-                NocNotificationHelper.buildPersonalisationWithPartyName(caseDataNew, partyName)
+                NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsNew, partyName)
             );
         }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocRespondentRepresentativeService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocRespondentRepresentativeService.java
@@ -144,7 +144,8 @@ public class NocRespondentRepresentativeService {
     @SuppressWarnings({"PMD.PrematureDeclaration", "checkstyle:VariableDeclarationUsageDistance"})
     public void updateRepresentativesAccess(CallbackRequest callbackRequest) throws IOException {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
-        CaseData caseDataBefore = callbackRequest.getCaseDetailsBefore().getCaseData();
+        CaseDetails caseDetailsBefore = callbackRequest.getCaseDetailsBefore();
+        CaseData caseDataBefore = caseDetailsBefore.getCaseData();
         CaseData caseData = caseDetails.getCaseData();
 
         List<ChangeOrganisationRequest> changeRequests = identifyRepresentationChanges(caseData,
@@ -161,7 +162,7 @@ public class NocRespondentRepresentativeService {
             log.info("Representation change applied {}", changeRequest);
 
             try {
-                nocNotificationService.sendNotificationOfChangeEmails(caseDataBefore, caseData, changeRequest);
+                nocNotificationService.sendNotificationOfChangeEmails(caseDetailsBefore, caseDetails, changeRequest);
             } catch (Exception exception) {
                 log.error(exception.getMessage(), exception);
             }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
@@ -28,6 +28,7 @@ class NocNotificationHelperTest {
     private static final String OLD_ORG_ID = "2";
 
     private CaseData caseData;
+    private CaseDetails caseDetails;
 
     private RespondentSumType respondentSumType;
 
@@ -45,7 +46,7 @@ class NocNotificationHelperTest {
                 .organisationID(OLD_ORG_ID)
                 .organisationName("Old Organisation").build();
 
-        CaseDetails caseDetails = CaseDataBuilder.builder()
+        caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("12345/6789")
             .withClaimantType("claimant@unrepresented.com")
             .withRepresentativeClaimantType("Claimant Rep", "claimant@represented.com")
@@ -79,8 +80,8 @@ class NocNotificationHelperTest {
     @Test
     void testbuildClaimantPersonalisation() {
         Map<String, String> claimantPersonalisation =
-            NocNotificationHelper.buildPersonalisationWithPartyName(caseData, "test_party");
-        assertThat(claimantPersonalisation.size(), is(4));
+            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party");
+        assertThat(claimantPersonalisation.size(), is(5));
         for (String value : claimantPersonalisation.values()) {
             assertThat(value, notNullValue());
         }
@@ -99,8 +100,8 @@ class NocNotificationHelperTest {
     @Test
     void testBuildNewRespondentSolicitorPersonalisation() {
         Map<String, String> claimantPersonalisation =
-            NocNotificationHelper.buildPersonalisationWithPartyName(caseData, "test_party");
-        assertThat(claimantPersonalisation.size(), is(4));
+            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party");
+        assertThat(claimantPersonalisation.size(), is(5));
         for (String value : claimantPersonalisation.values()) {
             assertThat(value, notNullValue());
         }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
@@ -94,6 +94,8 @@ class NocNotificationServiceTest {
                 null)
             .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 
+        caseDetailsBefore.setCaseId("1682497607486678");
+        caseDetailsNew.setCaseId("1682497607486678");
         caseDetailsBefore.getCaseData().setClaimant("Claimant LastName");
         caseDetailsNew.getCaseData().setClaimant("Claimant LastName");
         caseDetailsBefore.getCaseData().setTribunalCorrespondenceEmail("respondent@unrepresented.com");
@@ -106,8 +108,8 @@ class NocNotificationServiceTest {
         respondentSumType.setRespondentEmail("res@rep.com");
         when(nocRespondentHelper.getRespondent(any(), any())).thenReturn(respondentSumType);
         nocNotificationService.sendNotificationOfChangeEmails(
-                caseDetailsBefore.getCaseData(),
-                caseDetailsNew.getCaseData(),
+                caseDetailsBefore,
+                caseDetailsNew,
                 caseDetailsBefore.getCaseData().getChangeOrganisationRequestField());
         // Claimant
         verify(emailService, times(1)).sendEmail(any(), eq("claimant@represented.com"), any());
@@ -142,8 +144,8 @@ class NocNotificationServiceTest {
         when(nocRespondentHelper.getRespondent(any(), any())).thenReturn(respondentSumType);
 
         nocNotificationService.sendNotificationOfChangeEmails(
-                caseDetailsBefore.getCaseData(),
-                caseDetailsNew.getCaseData(),
+                caseDetailsBefore,
+                caseDetailsNew,
                 caseDetailsBefore.getCaseData().getChangeOrganisationRequestField());
         verify(emailService, times(0)).sendEmail(any(), any(), any());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3279

### Change description ###

Adjusted NoC claimant email template away from placeholder url and linking to a specific case id

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
