### PR TITLE
Ret 3488

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -384,7 +384,7 @@ dependencies {
     // Contract Tests
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.5.5'
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'java8', version: '4.1.41'
-    contractTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.7.4'
+    contractTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.7.11'
     contractTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion
     contractTestRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitJupiterVersion
     contractTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -317,7 +317,7 @@ dependencies {
     implementation group: 'org.apache.santuario', name: 'xmlsec', version: '3.0.1'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion
-    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.7.5'
+    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.7.8'
     //to remove CVEs
     implementation group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.16', ext: 'pom'
     //To Remove vulnerability CVE-2020-11988

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'checkstyle'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.11'
     id 'org.owasp.dependencycheck' version '8.0.1'
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'au.com.dius.pact' version '4.3.15'

--- a/charts/et-cos/Chart.yaml
+++ b/charts/et-cos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: et-cos
 home: https://github.com/hmcts/et-ccd-callbacks
-version: 0.0.24
+version: 0.0.25
 description: HMCTS Employment Tribunals CCD Callbacks service
 maintainers:
   - name: HMCTS Employment Tribunals Team

--- a/charts/et-cos/Chart.yaml
+++ b/charts/et-cos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: et-cos
 home: https://github.com/hmcts/et-ccd-callbacks
-version: 0.0.25
+version: 0.0.24
 description: HMCTS Employment Tribunals CCD Callbacks service
 maintainers:
   - name: HMCTS Employment Tribunals Team

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/HearingDetailsController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/HearingDetailsController.java
@@ -112,6 +112,7 @@ public class HearingDetailsController {
     public ResponseEntity<CCDCallbackResponse> aboutToSubmit(
             @RequestBody CCDRequest ccdRequest,
             @RequestHeader(value = "Authorization") String userToken) {
+
         if (!verifyTokenService.verifyTokenSignature(userToken)) {
             log.error(INVALID_TOKEN, userToken);
             return ResponseEntity.status(FORBIDDEN.value()).build();

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/FlagsImageHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/FlagsImageHelper.java
@@ -180,11 +180,13 @@ public class FlagsImageHelper {
 
         for (HearingTypeItem hearingTypeItem : caseData.getHearingCollection()) {
             HearingType hearingType = hearingTypeItem.getValue();
-            if (CollectionUtils.isNotEmpty(hearingType.getHearingDateCollection())) {
+            if (hearingType != null && CollectionUtils.isNotEmpty(hearingType.getHearingDateCollection())) {
                 for (DateListedTypeItem dateListedTypeItem : hearingType.getHearingDateCollection()) {
-                    String hearingReservedJudgement = dateListedTypeItem.getValue().getHearingReservedJudgement();
-                    if (YES.equals(hearingReservedJudgement)) {
-                        return true;
+                    if(dateListedTypeItem != null && dateListedTypeItem.getValue() != null) {
+                        String hearingReservedJudgement = dateListedTypeItem.getValue().getHearingReservedJudgement();
+                        if (YES.equals(hearingReservedJudgement)) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/FlagsImageHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/FlagsImageHelper.java
@@ -30,7 +30,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ZERO;
     "PMD.UnnecessaryAnnotationValueElement", "PMD.ExcessivePublicCount", "PMD.ExcessiveClassLength",
     "PMD.GodClass", "PMD.ConfusingTernary", "PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal",
     "PMD.ImplicitSwitchFallThrough", "PMD.ConsecutiveAppendsShouldReuse", "PMD.LawOfDemeter",
-    "PMD.CyclomaticComplexity"})
+    "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
 public class FlagsImageHelper {
 
     private static final String COLOR_ORANGE = "Orange";
@@ -182,7 +182,7 @@ public class FlagsImageHelper {
             HearingType hearingType = hearingTypeItem.getValue();
             if (hearingType != null && CollectionUtils.isNotEmpty(hearingType.getHearingDateCollection())) {
                 for (DateListedTypeItem dateListedTypeItem : hearingType.getHearingDateCollection()) {
-                    if(dateListedTypeItem != null && dateListedTypeItem.getValue() != null) {
+                    if (dateListedTypeItem != null && dateListedTypeItem.getValue() != null) {
                         String hearingReservedJudgement = dateListedTypeItem.getValue().getHearingReservedJudgement();
                         if (YES.equals(hearingReservedJudgement)) {
                             return true;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Helper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Helper.java
@@ -230,19 +230,22 @@ public final class Helper {
         if (caseData.getHearingCollection() != null) {
             for (HearingTypeItem hearingTypeItem : caseData.getHearingCollection()) {
 
-                if (hearingTypeItem.getValue().getHearingDateCollection() != null) {
+                if (hearingTypeItem.getValue() != null
+                    && hearingTypeItem.getValue().getHearingDateCollection() != null) {
                     for (DateListedTypeItem dateListedTypeItem
                             : hearingTypeItem.getValue().getHearingDateCollection()) {
 
                         DateListedType dateListedType = dateListedTypeItem.getValue();
-                        if (isHearingStatusPostponed(dateListedType) && dateListedType.getPostponedDate() == null) {
-                            dateListedType.setPostponedDate(UtilHelper.formatCurrentDate2(LocalDate.now()));
-                        }
-                        if (dateListedType.getPostponedDate() != null
-                                &&
-                                (!isHearingStatusPostponed(dateListedType)
-                                        || dateListedType.getHearingStatus() == null)) {
-                            dateListedType.setPostponedDate(null);
+                        if (dateListedType != null) {
+                            if (isHearingStatusPostponed(dateListedType)
+                                && dateListedType.getPostponedDate() == null) {
+                                dateListedType.setPostponedDate(UtilHelper.formatCurrentDate2(LocalDate.now()));
+                            }
+                            if (dateListedType.getPostponedDate() != null
+                                && (!isHearingStatusPostponed(dateListedType)
+                                    || dateListedType.getHearingStatus() == null)) {
+                                dateListedType.setPostponedDate(null);
+                            }
                         }
                     }
                 }
@@ -253,7 +256,7 @@ public final class Helper {
 
     private static boolean isHearingStatusPostponed(DateListedType dateListedType) {
         return dateListedType.getHearingStatus() != null
-                && dateListedType.getHearingStatus().equals(HEARING_STATUS_POSTPONED);
+                && HEARING_STATUS_POSTPONED.equals(dateListedType.getHearingStatus());
     }
 
     public static List<String> getJurCodesCollection(List<JurCodesTypeItem> jurCodesCollection) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/HearingSelectionService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/HearingSelectionService.java
@@ -45,8 +45,7 @@ public class HearingSelectionService {
     }
 
     public HearingType getSelectedHearingAllocateHearing(CaseData caseData) {
-        DynamicFixedListType dynamicFixedListType = caseData.getAllocateHearingHearing();
-        String id = dynamicFixedListType.getValue().getCode();
+        String id = caseData.getAllocateHearingHearing().getValue().getCode();
         for (HearingTypeItem hearing : caseData.getHearingCollection()) {
             for (DateListedTypeItem listing : hearing.getValue().getHearingDateCollection()) {
                 if (listing.getId().equals(id)) {
@@ -55,7 +54,7 @@ public class HearingSelectionService {
             }
         }
         throw new IllegalStateException(String.format("Selected hearing %s not found in case %s",
-                dynamicFixedListType.getValue().getLabel(), caseData.getEthosCaseReference()));
+            caseData.getAllocateHearingHearing().getValue().getLabel(), caseData.getEthosCaseReference()));
     }
 
     public HearingType getSelectedHearing(CaseData caseData, DynamicFixedListType dynamicFixedListType) {
@@ -69,7 +68,8 @@ public class HearingSelectionService {
                 dynamicFixedListType.getValue().getLabel(), caseData.getEthosCaseReference()));
     }
 
-    public List<DateListedTypeItem> getDateListedItemFromSelectedHearing(CaseData caseData, DynamicFixedListType dynamicFixedListType) {
+    public List<DateListedTypeItem> getDateListedItemsFromSelectedHearing(CaseData caseData,
+                                                                         DynamicFixedListType dynamicFixedListType) {
         return getSelectedHearing(caseData, dynamicFixedListType).getHearingDateCollection();
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/HearingSelectionService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/HearingSelectionService.java
@@ -69,6 +69,10 @@ public class HearingSelectionService {
                 dynamicFixedListType.getValue().getLabel(), caseData.getEthosCaseReference()));
     }
 
+    public List<DateListedTypeItem> getDateListedItemFromSelectedHearing(CaseData caseData, DynamicFixedListType dynamicFixedListType) {
+        return getSelectedHearing(caseData, dynamicFixedListType).getHearingDateCollection();
+    }
+
     public DateListedType getSelectedListing(CaseData caseData) {
         DynamicFixedListType dynamicFixedListType = caseData.getAllocateHearingHearing();
         String id = dynamicFixedListType.getValue().getCode();

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
@@ -35,12 +35,11 @@ public class HearingDetailsService {
     }
 
     public void handleListingSelected(CaseData caseData) {
-
         HearingType selectedHearing = getSelectedHearing(caseData);
         HearingDetailTypeItem hearingDetailTypeItem;
         HearingDetailType hearingDetailType;
         List<HearingDetailTypeItem> hearingDetailTypeItemList = new ArrayList<>();
-        if (selectedHearing != null && !CollectionUtils.isEmpty(selectedHearing.getHearingDateCollection())) {
+        if (!CollectionUtils.isEmpty(selectedHearing.getHearingDateCollection())) {
             for (DateListedTypeItem dateListedTypeItem : selectedHearing.getHearingDateCollection()) {
                 DateListedType dateListedType = dateListedTypeItem.getValue();
                 hearingDetailTypeItem = new HearingDetailTypeItem();
@@ -82,42 +81,58 @@ public class HearingDetailsService {
     }
 
     public void updateCase(CaseDetails caseDetails) {
-        CaseData caseData = caseDetails.getCaseData();
-        HearingType selectedHearing = getSelectedHearing(caseData);
-        if (!CollectionUtils.isEmpty(selectedHearing.getHearingDateCollection())) {
-            for (DateListedTypeItem dateListedTypeItem : selectedHearing.getHearingDateCollection()) {
-                DateListedType dateListedType = dateListedTypeItem.getValue();
-                for (HearingDetailTypeItem hearingDetailTypeItem : caseData.getHearingDetailsCollection()) {
-                    HearingDetailType hearingDetailType = hearingDetailTypeItem.getValue();
-                    if (hearingDetailType.getHearingDetailsDate().equals(dateListedType.getListedDate())) {
-                        dateListedType.setHearingStatus(hearingDetailType.getHearingDetailsStatus());
-                        dateListedType.setPostponedBy(hearingDetailType.getHearingDetailsPostponedBy());
-                        dateListedType.setHearingCaseDisposed(hearingDetailType.getHearingDetailsCaseDisposed());
-                        dateListedType.setHearingPartHeard(hearingDetailType.getHearingDetailsPartHeard());
-                        dateListedType.setHearingReservedJudgement(
-                                hearingDetailType.getHearingDetailsReservedJudgment());
-                        dateListedType.setAttendeeClaimant(hearingDetailType.getHearingDetailsAttendeeClaimant());
-                        dateListedType.setAttendeeNonAttendees(
-                                hearingDetailType.getHearingDetailsAttendeeNonAttendees());
-                        dateListedType.setAttendeeRespNoRep(hearingDetailType.getHearingDetailsAttendeeRespNoRep());
-                        dateListedType.setAttendeeRespAndRep(hearingDetailType.getHearingDetailsAttendeeRespAndRep());
-                        dateListedType.setAttendeeRepOnly(hearingDetailType.getHearingDetailsAttendeeRepOnly());
-                        dateListedType.setHearingTimingStart(hearingDetailType.getHearingDetailsTimingStart());
-                        dateListedType.setHearingTimingBreak(hearingDetailType.getHearingDetailsTimingBreak());
-                        dateListedType.setHearingTimingResume(hearingDetailType.getHearingDetailsTimingResume());
-                        dateListedType.setHearingTimingFinish(hearingDetailType.getHearingDetailsTimingFinish());
-                        dateListedType.setHearingTimingDuration(hearingDetailType.getHearingDetailsTimingDuration());
-                        dateListedType.setHearingNotes2(hearingDetailType.getHearingDetailsHearingNotes2());
+            CaseData caseData = caseDetails.getCaseData();
+            List<DateListedTypeItem> dateListedTypeItems = getDateListedItemFromSelectedHearing(caseData);
+            List<HearingDetailTypeItem> hearingDetailTypeItemsList = caseData.getHearingDetailsCollection();
+            if (!CollectionUtils.isEmpty(hearingDetailTypeItemsList)
+                && !CollectionUtils.isEmpty(dateListedTypeItems)) {
+                for (DateListedTypeItem dateListedTypeItem : dateListedTypeItems) {
+                    DateListedType dateListedType = dateListedTypeItem.getValue();
+                    if (dateListedType != null) {
+                        for (HearingDetailTypeItem hearingDetailTypeItem : hearingDetailTypeItemsList) {
+                            HearingDetailType hearingDetailType = hearingDetailTypeItem.getValue();
+                            if (hearingDetailType != null &&
+                                hearingDetailType.getHearingDetailsDate() != null &&
+                                hearingDetailType.getHearingDetailsDate().equals(dateListedType.getListedDate())) {
+                                updateDateListedTypeDetails(dateListedType, hearingDetailType);
+                            }
+                        }
                     }
                 }
+
+                Helper.updatePostponedDate(caseData);
             }
-        }
-        Helper.updatePostponedDate(caseData);
-        FlagsImageHelper.buildFlagsImageFileName(caseDetails);
+
+            FlagsImageHelper.buildFlagsImageFileName(caseDetails);
+    }
+
+    private List<DateListedTypeItem> getDateListedItemFromSelectedHearing(CaseData caseData) {
+        return hearingSelectionService.getDateListedItemFromSelectedHearing(caseData,
+            caseData.getHearingDetailsHearing());
     }
 
     private HearingType getSelectedHearing(CaseData caseData) {
         return hearingSelectionService.getSelectedHearing(caseData, caseData.getHearingDetailsHearing());
     }
 
+    private void updateDateListedTypeDetails(DateListedType dateListedType, HearingDetailType hearingDetailType ) {
+        dateListedType.setHearingStatus(hearingDetailType.getHearingDetailsStatus());
+        dateListedType.setPostponedBy(hearingDetailType.getHearingDetailsPostponedBy());
+        dateListedType.setHearingCaseDisposed(hearingDetailType.getHearingDetailsCaseDisposed());
+        dateListedType.setHearingPartHeard(hearingDetailType.getHearingDetailsPartHeard());
+        dateListedType.setHearingReservedJudgement(
+            hearingDetailType.getHearingDetailsReservedJudgment());
+        dateListedType.setAttendeeClaimant(hearingDetailType.getHearingDetailsAttendeeClaimant());
+        dateListedType.setAttendeeNonAttendees(
+            hearingDetailType.getHearingDetailsAttendeeNonAttendees());
+        dateListedType.setAttendeeRespNoRep(hearingDetailType.getHearingDetailsAttendeeRespNoRep());
+        dateListedType.setAttendeeRespAndRep(hearingDetailType.getHearingDetailsAttendeeRespAndRep());
+        dateListedType.setAttendeeRepOnly(hearingDetailType.getHearingDetailsAttendeeRepOnly());
+        dateListedType.setHearingTimingStart(hearingDetailType.getHearingDetailsTimingStart());
+        dateListedType.setHearingTimingBreak(hearingDetailType.getHearingDetailsTimingBreak());
+        dateListedType.setHearingTimingResume(hearingDetailType.getHearingDetailsTimingResume());
+        dateListedType.setHearingTimingFinish(hearingDetailType.getHearingDetailsTimingFinish());
+        dateListedType.setHearingTimingDuration(hearingDetailType.getHearingDetailsTimingDuration());
+        dateListedType.setHearingNotes2(hearingDetailType.getHearingDetailsHearingNotes2());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
@@ -82,8 +82,10 @@ public class HearingDetailsService {
 
     public void updateCase(CaseDetails caseDetails) {
         CaseData caseData = caseDetails.getCaseData();
-        List<DateListedTypeItem> dateListedTypeItems = getDateListedItemFromSelectedHearing(caseData);
+        // A collection of hearing update detail entries
         List<HearingDetailTypeItem> hearingDetailTypeItemsList = caseData.getHearingDetailsCollection();
+        // The DateListedTypeItems from the currently selected hearing, to which the hearing updates get applied
+        List<DateListedTypeItem> dateListedTypeItems = getDateListedItemFromSelectedHearing(caseData);
 
         if (!CollectionUtils.isEmpty(hearingDetailTypeItemsList)
             && !CollectionUtils.isEmpty(dateListedTypeItems)) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
@@ -39,7 +39,7 @@ public class HearingDetailsService {
         HearingDetailTypeItem hearingDetailTypeItem;
         HearingDetailType hearingDetailType;
         List<HearingDetailTypeItem> hearingDetailTypeItemList = new ArrayList<>();
-        if (!CollectionUtils.isEmpty(selectedHearing.getHearingDateCollection())) {
+        if (selectedHearing != null && !CollectionUtils.isEmpty(selectedHearing.getHearingDateCollection())) {
             for (DateListedTypeItem dateListedTypeItem : selectedHearing.getHearingDateCollection()) {
                 DateListedType dateListedType = dateListedTypeItem.getValue();
                 hearingDetailTypeItem = new HearingDetailTypeItem();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailServiceTest.java
@@ -268,6 +268,8 @@ public class HearingDetailServiceTest {
         hearingType.setHearingDateCollection(List.of(dateListedTypeItem));
         when(hearingSelectionService.getSelectedHearing(isA(CaseData.class), isA(DynamicFixedListType.class)))
                 .thenReturn(hearingType);
+        when(hearingSelectionService.getDateListedItemFromSelectedHearing(isA(CaseData.class), isA(DynamicFixedListType.class)))
+                .thenReturn(List.of(dateListedTypeItem));
         return hearingSelectionService;
     }
 


### PR DESCRIPTION
The code changes made prevent null pointer exception that occurs when the user attempts adding one or more Hearing Date item for a selected hearing while updating a hearing. During a hearing update (via Hearing details event), changes to the Hearing Date items are persisted and any possible new entry(newly added Hearing Date item/s) get ignored. 

https://tools.hmcts.net/jira/browse/RET-3488


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
