### PR TITLE
RET-3549: Falling back to display basic file link when metadata cannot be reached

### DIFF
--- a/charts/et-cos/Chart.yaml
+++ b/charts/et-cos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: et-cos
 home: https://github.com/hmcts/et-ccd-callbacks
-version: 0.0.25
+version: 0.0.26
 description: HMCTS Employment Tribunals CCD Callbacks service
 maintainers:
   - name: HMCTS Employment Tribunals Team


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3549

### Change description ###

Falling back to display basic file link when metadata cannot be reached

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
