### PR TITLE
RET-3688: Removed unused notStartedYet notification status

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT_ONLY;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
-import static uk.gov.hmcts.ecm.common.model.helper.Constants.NOT_STARTED_YET;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.NOT_VIEWED_YET;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.RESPONDENT_ONLY;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.TRIBUNAL;
@@ -103,11 +102,7 @@ public class SendNotificationService {
         sendNotificationType.setSendNotificationRequestMadeBy(caseData.getSendNotificationRequestMadeBy());
         sendNotificationType.setSendNotificationEccQuestion(caseData.getSendNotificationEccQuestion());
         sendNotificationType.setSendNotificationWhoMadeJudgement(caseData.getSendNotificationWhoMadeJudgement());
-        if (RESPONDENT_ONLY.equals(sendNotificationType.getSendNotificationSelectParties())) {
-            sendNotificationType.setNotificationState(NOT_VIEWED_YET);
-        } else {
-            sendNotificationType.setNotificationState(NOT_STARTED_YET);
-        }
+        sendNotificationType.setNotificationState(NOT_VIEWED_YET);
 
         sendNotificationType.setSendNotificationSentBy(TRIBUNAL);
         sendNotificationType.setSendNotificationSubjectString(

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationServiceTest.java
@@ -111,7 +111,7 @@ class SendNotificationServiceTest {
         assertEquals("Other", sendNotificationType.getSendNotificationDecision());
         assertEquals("details", sendNotificationType.getSendNotificationDetails());
         assertEquals("Judge", sendNotificationType.getSendNotificationRequestMadeBy());
-        assertEquals("notStartedYet", sendNotificationType.getNotificationState());
+        assertEquals(NOT_VIEWED_YET, sendNotificationType.getNotificationState());
         assertEquals(YES, sendNotificationType.getSendNotificationResponseTribunalTable());
         assertEquals("Hearing, Judgment", sendNotificationType.getSendNotificationSubjectString());
         assertEquals("0", sendNotificationType.getSendNotificationResponsesCount());


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
