### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
-    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '5.1.9'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.31'
 
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.