### PR TITLE
RET-3514 Allow Non System Users Respond to an Application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,7 @@ dependencyManagement {
 dependencies {
 
     implementation group: 'com.github.hmcts', name: 'et-common', version:'1.2.0'
-    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'2.4.0'
+    implementation group: 'com.github.hmcts', name: 'et-data-model', version:'2.6.3'
 
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ ext {
     pact_version = '4.3.10'
     reformLoggingVersion = '5.1.9'
     serenity = '3.7.1'
-    tomcatEmbedVersion = '9.0.75'
+    tomcatEmbedVersion = '9.0.80'
 }
 
 ext["rest-assured.version"] = '5.1.0'

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondentTellSomethingElseController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondentTellSomethingElseController.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationTypeItem;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.RespondentTellSomethingElseService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
@@ -82,6 +83,7 @@ public class RespondentTellSomethingElseController {
             return ResponseEntity.status(FORBIDDEN.value()).build();
         }
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
+        TseHelper.setSystemUserYesOrNoField(caseData);
         return getCallbackRespEntityNoErrors(caseData);
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyController.java
@@ -83,10 +83,6 @@ public class TseRespondentReplyController {
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
         caseData.setTseRespondSelectApplication(TseHelper.populateRespondentSelectApplication(caseData));
 
-        if (Helper.isClaimantNonSystemUser(caseData)) {
-            caseData.setTseRespondNotAvailableWarning(YES);
-        }
-
         return getCallbackRespEntityNoErrors(caseData);
     }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseHelper.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLOSED_STATE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.NEW_DATE_PATTERN;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.RESPONDENT_TITLE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.APPLICATION_TYPE;
@@ -79,6 +80,14 @@ public final class TseHelper {
                 )
                 .map(TseHelper::formatDropdownOption)
                 .toList());
+    }
+
+    public static void setSystemUserYesOrNoField(CaseData caseData) {
+        if (Helper.isClaimantNonSystemUser(caseData)) {
+            caseData.setSystemUserYesOrNo(NO);
+        } else {
+            caseData.setSystemUserYesOrNo(YES);
+        }
     }
 
     private static boolean isNoRespondentReply(List<TseRespondTypeItem> tseRespondTypeItems) {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyControllerTest.java
@@ -94,8 +94,6 @@ class TseRespondentReplyControllerTest {
             .andExpect(jsonPath(JsonMapper.DATA, notNullValue()))
             .andExpect(jsonPath(JsonMapper.ERRORS, nullValue()))
             .andExpect(jsonPath(JsonMapper.WARNINGS, nullValue()));
-
-        mockHelper.verify(() -> Helper.isClaimantNonSystemUser(any()), times(1));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3514

-----

### Change description ###

Removed the control for claimants who are not system users. And added the text resTseCopyThisCorrespondenceTextBold

-----

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
