### PR TITLE
ret-3891 implementation added

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdmReplyController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdmReplyController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.et.common.model.ccd.CCDCallbackResponse;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseAdmReplyService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 
@@ -122,9 +123,13 @@ public class TseAdmReplyController {
             return ResponseEntity.status(FORBIDDEN.value()).build();
         }
 
-        CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
+        CaseDetails caseDetails = ccdRequest.getCaseDetails();
+        CaseData caseData = caseDetails.getCaseData();
         tseAdmReplyService.updateApplicationState(caseData);
         tseAdmReplyService.saveTseAdmReplyDataFromCaseData(caseData);
+
+        // Generate a pdf copy of the CYA page of the Tse Admin reply application
+        tseAdmReplyService.addTseAdmReplyPdfToDocCollection(caseDetails, userToken);
         tseAdmReplyService.sendNotifyEmailsToClaimant(ccdRequest.getCaseDetails().getCaseId(), caseData);
         tseAdmReplyService.sendNotifyEmailsToRespondents(ccdRequest.getCaseDetails());
         tseAdmReplyService.clearTseAdmReplyDataFromCaseData(caseData);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdminController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdminController.java
@@ -98,6 +98,7 @@ public class TseAdminController {
 
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
         tseAdminService.saveTseAdminDataFromCaseData(caseData);
+        tseAdminService.addTseAdminDecisionPdfToDocCollection(ccdRequest.getCaseDetails(), userToken);
         tseAdminService.sendEmailToClaimant(ccdRequest.getCaseDetails().getCaseId(), caseData);
         tseAdminService.sendNotifyEmailsToRespondents(ccdRequest.getCaseDetails());
         tseAdminService.clearTseAdminDataFromCaseData(caseData);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyController.java
@@ -225,8 +225,7 @@ public class TseRespondentReplyController {
 
         CaseDetails caseDetails = ccdRequest.getCaseDetails();
         CaseData caseData = caseDetails.getCaseData();
-        tseRespondentReplyService.addTseRespondentReplyPdfToDocCollection(caseData, userToken,
-            caseDetails.getCaseTypeId());
+        tseRespondentReplyService.addTseRespondentReplyPdfToDocCollection(caseDetails, userToken);
         tseRespondentReplyService.respondentReplyToTse(userToken, caseDetails, caseData);
 
         return getCallbackRespEntityNoErrors(caseData);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
@@ -2,12 +2,14 @@ package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 /**
  * This object captures information related to the TseAdminDecisionRecord object during
  * the doc creation event for Docmosis.
  */
+@EqualsAndHashCode(callSuper = true)
 @SuperBuilder
 @Data
 public class TseAdminDecisionRecordData extends TseReplyData {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
@@ -9,7 +9,7 @@ import lombok.experimental.SuperBuilder;
  * This object captures information related to the TseAdminDecisionRecord object during
  * the doc creation event for Docmosis.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @SuperBuilder
 @Data
 public class TseAdminDecisionRecordData extends TseReplyData {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * This object captures information related to the TseAdminDecisionRecord object during
+ * the doc creation event for Docmosis.
+ */
+@SuperBuilder
+@Data
+public class TseAdminDecisionRecordData extends TseReplyData {
+    @JsonProperty("notificationTitle")
+    private String notificationTitle;
+    @JsonProperty("tseAdminDecision")
+    private String tseAdminDecision;
+    @JsonProperty("tseAdminTypeOfDecision")
+    private String tseAdminTypeOfDecision;
+    @JsonProperty("tseAdminIsResponseRequired")
+    private String tseAdminIsResponseRequired;
+    @JsonProperty("tseAdminSelectPartyRespond")
+    private String tseAdminSelectPartyRespond;
+    @JsonProperty("tseAdminAdditionalInformation")
+    private String tseAdminAdditionalInformation;
+    @JsonProperty("tseAdminDecisionMadeBy")
+    private String tseAdminDecisionMadeBy;
+    @JsonProperty("tseAdminDecisionMadeByFullName")
+    private String tseAdminDecisionMadeByFullName;
+    @JsonProperty("tseAdminSelectPartyNotify")
+    private String tseAdminSelectPartyNotify;
+}

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminDecisionRecordData.java
@@ -1,17 +1,23 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 /**
  * This object captures information related to the TseAdminDecisionRecord object during
  * the doc creation event for Docmosis.
  */
-@EqualsAndHashCode(callSuper = false)
-@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TseAdminDecisionRecordData extends TseReplyData {
     @JsonProperty("notificationTitle")
     private String notificationTitle;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * This object captures information related to the TseAdminReply object during
+ * the document creation event for Docmosis.
+ */
+@SuperBuilder
+@Data
+public class TseAdminReplyData extends TseReplyData {
+    @JsonProperty("responseTitle")
+    private String responseTitle;
+    @JsonProperty("responseAdditionalInfo")
+    private String responseAdditionalInfo;
+    @JsonProperty("isCmoOrRequest")
+    private String isCmoOrRequest;
+    @JsonProperty("cmoMadeBy")
+    private String cmoMadeBy;
+    @JsonProperty("cmoEnterFullName")
+    private String cmoEnterFullName;
+    @JsonProperty("cmoIsResponseRequired")
+    private String cmoIsResponseRequired;
+    @JsonProperty("cmoSelectPartyRespond")
+    private String cmoSelectPartyRespond;
+    @JsonProperty("requestMadeBy")
+    private String requestMadeBy;
+    @JsonProperty("requestEnterFullName")
+    private String requestEnterFullName;
+    @JsonProperty("requestIsResponseRequired")
+    private String requestIsResponseRequired;
+    @JsonProperty("requestSelectPartyRespond")
+    private String requestSelectPartyRespond;
+    @JsonProperty("selectPartyNotify")
+    private String selectPartyNotify;
+}

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
@@ -1,17 +1,23 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 /**
  * This object captures information related to the TseAdminReply object during
  * the document creation event for Docmosis.
  */
-@EqualsAndHashCode(callSuper = false)
-@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TseAdminReplyData extends TseReplyData {
     @JsonProperty("responseTitle")
     private String responseTitle;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
@@ -2,12 +2,14 @@ package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 /**
  * This object captures information related to the TseAdminReply object during
  * the document creation event for Docmosis.
  */
+@EqualsAndHashCode(callSuper = true)
 @SuperBuilder
 @Data
 public class TseAdminReplyData extends TseReplyData {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseAdminReplyData.java
@@ -9,7 +9,7 @@ import lombok.experimental.SuperBuilder;
  * This object captures information related to the TseAdminReply object during
  * the document creation event for Docmosis.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @SuperBuilder
 @Data
 public class TseAdminReplyData extends TseReplyData {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseReplyData.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TseReplyData.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
@@ -11,8 +14,11 @@ import java.util.List;
 /**
  * This object captures information related to the TseReply object during creation event for docmosis.
  */
-@SuperBuilder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TseReplyData {
     @JsonProperty("caseNumber")
     private String caseNumber;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Constants.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Constants.java
@@ -64,4 +64,8 @@ public class Constants {
     public static final int FIVE_ACAS_DOC_TYPE_ITEMS_COUNT = 5;
     public static final int ONE_RESPONDENT_COUNT = 1;
     public static final String DOCGEN_ERROR = "Failed to generate document for case id: %s";
+    public static final String RECORD_DECISION = "Record decision";
+    public static final String REPLY_TO_APPLICATION = "Reply to application";
+    public static final String TSE_ADMIN_CORRESPONDENCE = "Tse admin correspondence";
+    public static final String RESPONDENT_CORRESPONDENCE = "Respondent correspondence";
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
@@ -1,15 +1,43 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.helpers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections4.CollectionUtils;
+import uk.gov.hmcts.ecm.common.exceptions.DocumentManagementException;
+import uk.gov.hmcts.ecm.common.helpers.UtilHelper;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicValueType;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
+import uk.gov.hmcts.et.common.model.ccd.DocumentInfo;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
+import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.documents.TseAdminDecisionRecordData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.documents.TseAdminReplyData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.documents.TseReplyData;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.documents.TseReplyDocument;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentManagementService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLOSED_STATE;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Constants.DOCGEN_ERROR;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.DocumentHelper.createDocumentTypeItem;
 
 public final class TseAdminHelper {
+    private static final String TSE_ADMIN_REPLY_OUTPUT_NAME = "%s Reply.pdf";
+    private static final String TSE_ADMIN_REPLY_TEMPLATE_NAME = "EM-TRB-EGW-ENG-Admin-Tse-Reply.docx";
+    private static final String TSE_ADMIN_DECISION_TEMPLATE_NAME = "EM-TRB-EGW-ENG-Admin-Tse-Decision.docx";
+    private static final String CASE_MANAGEMENT_ORDER = "Case management order";
 
     private TseAdminHelper() {
         // Sonar Lint: Utility classes should not have public constructors
@@ -31,4 +59,150 @@ public final class TseAdminHelper {
             )
             .collect(Collectors.toList()));
     }
+
+    public static DocumentTypeItem getDocumentTypeItem(DocumentManagementService docService,
+                                                       TornadoService tornadoService, CaseDetails caseDetails,
+                                                       String userToken, String typeOfDocument,
+                                                       String typeOfCorrespondence) {
+        if (caseDetails == null) {
+            return null;
+        }
+        DocumentInfo eventDocInfo = getDocumentInfo(tornadoService, userToken, caseDetails, typeOfDocument);
+        String resTseSelectApp = caseDetails.getCaseData().getResTseSelectApplication();
+        return createDocumentTypeItem(docService.addDocumentToDocumentField(eventDocInfo),
+                typeOfCorrespondence, resTseSelectApp);
+    }
+
+    private static DocumentInfo getDocumentInfo(TornadoService tornadoService, String userToken,
+                                                CaseDetails caseDetails, String typeOfDocument) {
+        CaseData caseData = caseDetails.getCaseData();
+        try {
+            return tornadoService.generateEventDocument(caseData, userToken, caseDetails.getCaseTypeId(),
+                    typeOfDocument);
+        } catch (Exception e) {
+            throw new DocumentManagementException(String.format(DOCGEN_ERROR, caseData.getEthosCaseReference()), e);
+        }
+    }
+
+    +
+    public static String getReplyDocumentRequest(CaseData caseData, String accessKey) throws JsonProcessingException {
+        GenericTseApplicationType selectedApplication = getTseAdminSelectedApplicationType(caseData);
+        assert selectedApplication != null;
+
+        TseReplyData data = createDataForTseReply(caseData, selectedApplication);
+        TseReplyDocument document = TseReplyDocument.builder()
+                .accessKey(accessKey)
+                .outputName(String.format(TSE_ADMIN_REPLY_OUTPUT_NAME, selectedApplication.getType()))
+                .templateName(TSE_ADMIN_REPLY_TEMPLATE_NAME)
+                .data(data).build();
+        return new ObjectMapper().writeValueAsString(document);
+    }
+
+    public static String getAdminDecisionDocumentRequest(CaseData caseData, String accessKey) throws
+            JsonProcessingException {
+        GenericTseApplicationType selectedApplication = getTseAdminSelectedApplicationType(caseData);
+        assert selectedApplication != null;
+
+        TseReplyData data = createDataForTseAdminDecision(caseData, selectedApplication);
+        TseReplyDocument document = TseReplyDocument.builder()
+                .accessKey(accessKey)
+                .outputName(String.format(TSE_ADMIN_REPLY_OUTPUT_NAME, selectedApplication.getType()))
+                .templateName(TSE_ADMIN_DECISION_TEMPLATE_NAME)
+                .data(data).build();
+        return new ObjectMapper().writeValueAsString(document);
+    }
+
+    private static List<GenericTypeItem<DocumentType>> getSupportDocListForDecision(CaseData caseData) {
+        if (CASE_MANAGEMENT_ORDER.equals(caseData.getTseAdminTypeOfDecision())
+                && caseData.getTseAdminResponseRequiredYesDoc() != null) {
+            return caseData.getTseAdminResponseRequiredYesDoc();
+        } else {
+            return caseData.getTseAdminResponseRequiredNoDoc();
+        }
+    }
+
+    private static TseReplyData createDataForTseAdminDecision(CaseData caseData,
+                                                              GenericTseApplicationType application) {
+        List<GenericTypeItem<DocumentType>> supportDocList = getSupportDocListForDecision(caseData);
+        return TseAdminDecisionRecordData.builder()
+                .caseNumber(defaultIfEmpty(caseData.getEthosCaseReference(), null))
+                .respondentParty(application.getApplicant())
+                .type(defaultIfEmpty(application.getType(), null))
+                .responseDate(UtilHelper.formatCurrentDate(LocalDate.now()))
+                .tseAdminDecision(defaultIfEmpty(caseData.getTseAdminDecision(), null))
+                .tseAdminDecisionMadeBy(defaultIfEmpty(caseData.getTseAdminDecisionMadeBy(), null))
+                .tseAdminTypeOfDecision(defaultIfEmpty(caseData.getTseAdminTypeOfDecision(), null))
+                .notificationTitle(defaultIfEmpty(caseData.getTseAdminEnterNotificationTitle(), null))
+                .tseAdminAdditionalInformation(defaultIfEmpty(caseData.getTseAdminAdditionalInformation(),
+                        null))
+                .tseAdminDecisionMadeByFullName(defaultIfEmpty(caseData.getTseAdminDecisionMadeByFullName(),
+                        null))
+                .tseAdminIsResponseRequired(defaultIfEmpty(caseData.getTseAdminIsResponseRequired(), null))
+                .tseAdminSelectPartyNotify(defaultIfEmpty(caseData.getTseAdminSelectPartyNotify(), null))
+                .tseAdminSelectPartyRespond(defaultIfEmpty(caseData.getTseAdminSelectPartyRespond(), null))
+                .supportingYesNo(hasSupportingDocs(supportDocList))
+                .documentCollection(getUploadedDocList(supportDocList))
+                .build();
+    }
+
+    public static GenericTseApplicationType getTseAdminSelectedApplicationType(CaseData caseData) {
+        return caseData.getGenericTseApplicationCollection().stream()
+                .filter(item -> item.getValue().getNumber().equals(caseData.getTseAdminSelectApplication()
+                        .getSelectedCode()))
+                .findFirst()
+                .map(GenericTseApplicationTypeItem::getValue)
+                .orElse(null);
+    }
+
+    private static TseReplyData createDataForTseReply(CaseData caseData, GenericTseApplicationType application) {
+        String selectedCmoRespondent = caseData.getTseAdmReplyCmoSelectPartyRespond();
+        return TseAdminReplyData.builder()
+                .caseNumber(defaultIfEmpty(caseData.getEthosCaseReference(), null))
+                .respondentParty(application.getApplicant())
+                .type(defaultIfEmpty(application.getType(), null))
+                .responseDate(UtilHelper.formatCurrentDate(LocalDate.now()))
+                .response(defaultIfEmpty(application.getDetails(), null))
+                .supportingYesNo(hasSupportingDocs(caseData.getTseAdmReplyAddDocument()))
+                .documentCollection(getUploadedDocList(caseData.getTseAdmReplyAddDocument()))
+                .copy(defaultIfEmpty(application.getCopyToOtherPartyYesOrNo(), null))
+                .responseTitle(defaultIfEmpty(caseData.getTseAdmReplyEnterResponseTitle(), null))
+                .responseAdditionalInfo(defaultIfEmpty(caseData.getTseAdmReplyAdditionalInformation(), null))
+                .isCmoOrRequest(defaultIfEmpty(caseData.getTseAdmReplyIsCmoOrRequest(), null))
+                .cmoMadeBy(defaultIfEmpty(caseData.getTseAdmReplyCmoMadeBy(), null))
+                .cmoEnterFullName(defaultIfEmpty(caseData.getTseAdmReplyCmoEnterFullName(), null))
+                .cmoIsResponseRequired(defaultIfEmpty(caseData.getTseAdmReplyCmoIsResponseRequired(), null))
+                .cmoSelectPartyRespond(defaultIfEmpty(selectedCmoRespondent, null))
+                .requestMadeBy(defaultIfEmpty(caseData.getTseAdmReplyRequestMadeBy(), null))
+                .requestEnterFullName(defaultIfEmpty(caseData.getTseAdmReplyRequestEnterFullName(), null))
+                .requestIsResponseRequired(defaultIfEmpty(caseData.getTseAdmReplyRequestIsResponseRequired(),
+                        null))
+                .requestSelectPartyRespond(defaultIfEmpty(caseData.getTseAdmReplyRequestSelectPartyRespond(),
+                        null))
+                .selectPartyNotify(defaultIfEmpty(caseData.getTseAdmReplySelectPartyNotify(), null))
+                .build();
+    }
+
+    private static List<GenericTypeItem<DocumentType>> getUploadedDocList(
+            List<GenericTypeItem<DocumentType>> docTypeList) {
+        if (docTypeList == null) {
+            return null;
+        }
+
+        List<GenericTypeItem<DocumentType>> genericDocTypeList = new ArrayList<>();
+        docTypeList.forEach(doc -> {
+            GenericTypeItem<DocumentType> genTypeItems = new GenericTypeItem<>();
+            DocumentType docType = new DocumentType();
+            docType.setUploadedDocument(doc.getValue().getUploadedDocument());
+            genTypeItems.setId(doc.getId() != null ? doc.getId() : UUID.randomUUID().toString());
+            genTypeItems.setValue(docType);
+            genericDocTypeList.add(genTypeItems);
+        });
+
+        return genericDocTypeList;
+    }
+
+    private static String hasSupportingDocs(List<GenericTypeItem<DocumentType>> supportDocList) {
+        return (supportDocList != null && !supportDocList.isEmpty())  ? "Yes" : "No";
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
@@ -35,8 +35,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.DocumentHelper.cre
 
 public final class TseAdminHelper {
     private static final String TSE_ADMIN_REPLY_OUTPUT_NAME = "%s Reply.pdf";
-    private static final String TSE_ADMIN_REPLY_TEMPLATE_NAME = "EM-TRB-EGW-ENG-Admin-Tse-Reply.docx";
-    private static final String TSE_ADMIN_DECISION_TEMPLATE_NAME = "EM-TRB-EGW-ENG-Admin-Tse-Decision.docx";
+    private static final String TSE_ADMIN_REPLY_TEMPLATE_NAME = "EM-TRB-EGW-ENG-000991.docx";
+    private static final String TSE_ADMIN_DECISION_TEMPLATE_NAME = "EM-TRB-EGW-ENG-000992.docx";
     private static final String CASE_MANAGEMENT_ORDER = "Case management order";
 
     private TseAdminHelper() {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelper.java
@@ -84,7 +84,6 @@ public final class TseAdminHelper {
         }
     }
 
-    +
     public static String getReplyDocumentRequest(CaseData caseData, String accessKey) throws JsonProcessingException {
         GenericTseApplicationType selectedApplication = getTseAdminSelectedApplicationType(caseData);
         assert selectedApplication != null;

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TornadoService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TornadoService.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.ethos.replacement.docmosis.helpers.ReportDocHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.RespondentTellSomethingElseHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.SignificantItemType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TornadoDocumentFilter;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseAdminHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseHelper;
 
 import java.io.ByteArrayOutputStream;
@@ -51,7 +52,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentManagement
 public class TornadoService {
     public static final String TSE_FILE_NAME = "Contact the tribunal.pdf";
     public static final String TSE_REPLY = "TSE Reply.pdf";
-
+    public static final String TSE_ADMIN_REPLY = "TSE Admin Reply.pdf";
+    public static final String TSE_ADMIN_DECISION = "TSE Admin Decision.pdf";
     private static final String UNABLE_TO_CONNECT_TO_DOCMOSIS = "Unable to connect to Docmosis: ";
     private static final String OUTPUT_FILE_NAME_PDF = "document.pdf";
     private static final String ET3_RESPONSE_PDF = "ET3 Response.pdf";
@@ -360,6 +362,12 @@ public class TornadoService {
             }
             case TSE_REPLY -> {
                 return TseHelper.getReplyDocumentRequest(caseData, tornadoConnection.getAccessKey());
+            }
+            case "TSE Admin Reply.pdf" -> {
+                return TseAdminHelper.getReplyDocumentRequest(caseData, tornadoConnection.getAccessKey());
+            }
+            case "TSE Admin Decision.pdf" -> {
+                return TseAdminHelper.getAdminDecisionDocumentRequest(caseData, tornadoConnection.getAccessKey());
             }
             default -> throw new IllegalArgumentException("Unexpected document name " + documentName);
         }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseAdminService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseAdminService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ecm.common.helpers.UtilHelper;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.et.common.model.ccd.types.TseAdminRecordDecisionType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.NotificationHelper;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseAdminHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.TSEAdminEmailRecipientsData;
 
 import java.time.LocalDate;
@@ -28,14 +30,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.BOTH_PARTIES;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT_ONLY;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.CASE_NUMBER;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.LINK_TO_CITIZEN_HUB;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.LINK_TO_EXUI;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Constants.TSE_ADMIN_CORRESPONDENCE;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.MarkdownHelper.createTwoColumnTable;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseHelper.getAdminSelectedApplicationType;
+import static uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService.TSE_ADMIN_DECISION;
 
 @Slf4j
 @Service
@@ -49,6 +54,8 @@ public class TseAdminService {
     private String tseAdminRecordClaimantTemplateId;
     @Value("${template.tse.admin.record-a-decision.respondent}")
     private String tseAdminRecordRespondentTemplateId;
+    private final DocumentManagementService documentManagementService;
+    private final TornadoService tornadoService;
 
     /**
      * Initial Application and Respond details table.
@@ -107,6 +114,25 @@ public class TseAdminService {
                 .value(decision)
                 .build()
         );
+    }
+
+    /**
+     * Creates a pdf copy of the decision an Admin/Caseworker makes on TSE application and
+     * adds it to the case doc collection.
+     *
+     * @param caseDetails details of the case from which required fields are extracted
+     * @param userToken autherisation token to use for generating an event document
+     */
+    public void addTseAdminDecisionPdfToDocCollection(CaseDetails caseDetails, String userToken) {
+        CaseData caseData = caseDetails.getCaseData();
+
+        if (isEmpty(caseData.getDocumentCollection())) {
+            caseData.setDocumentCollection(new ArrayList<>());
+        }
+
+        DocumentTypeItem docTypeItem = TseAdminHelper.getDocumentTypeItem(documentManagementService, tornadoService,
+                caseDetails, userToken, TSE_ADMIN_DECISION, TSE_ADMIN_CORRESPONDENCE);
+        caseData.getDocumentCollection().add(docTypeItem);
     }
 
     private List<GenericTypeItem<DocumentType>> getResponseRequiredDocYesOrNo(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseRespondentReplyService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseRespondentReplyService.java
@@ -10,10 +10,10 @@ import uk.gov.hmcts.ecm.common.exceptions.DocumentManagementException;
 import uk.gov.hmcts.ecm.common.helpers.UtilHelper;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
-import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
 import uk.gov.hmcts.et.common.model.ccd.items.TseRespondTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.TseRespondType;
+import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseAdminHelper;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseHelper;
 
 import java.time.LocalDate;
@@ -36,7 +36,7 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServ
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.CASE_NUMBER;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.LINK_TO_CITIZEN_HUB;
 import static uk.gov.hmcts.ethos.replacement.docmosis.constants.NotificationServiceConstants.LINK_TO_EXUI;
-import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.DocumentHelper.createDocumentTypeItem;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Constants.RESPONDENT_CORRESPONDENCE;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.MarkdownHelper.createTwoColumnTable;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.TseHelper.getRespondentSelectedApplicationType;
 import static uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService.TSE_REPLY;
@@ -95,28 +95,18 @@ public class TseRespondentReplyService {
     /**
      * Creates a pdf copy of the TSE application Response from Respondent and adds it to the case doc collection.
      *
-     * @param caseData details of the case from which required fields are extracted
+     * @param caseDetails details of the case from which required fields are extracted
      * @param userToken autherisation token to use for generating an event document
-     * @param caseTypeId case type to use for generating an event document
      */
-    public void addTseRespondentReplyPdfToDocCollection(CaseData caseData, String userToken, String caseTypeId) {
-        try {
-            if (isEmpty(caseData.getDocumentCollection())) {
-                caseData.setDocumentCollection(new ArrayList<>());
-            }
+    public void addTseRespondentReplyPdfToDocCollection(CaseDetails caseDetails, String userToken) {
+        CaseData caseData = caseDetails.getCaseData();
 
-            DocumentTypeItem docItem = createDocumentTypeItem(
-                    documentManagementService.addDocumentToDocumentField(
-                            tornadoService.generateEventDocument(caseData, userToken, caseTypeId, TSE_REPLY)),
-                    "Respondent correspondence",
-                    caseData.getResTseSelectApplication()
-            );
-
-            caseData.getDocumentCollection().add(docItem);
-
-        } catch (Exception e) {
-            throw new DocumentManagementException(String.format(DOCGEN_ERROR, caseData.getEthosCaseReference()), e);
+        if (isEmpty(caseData.getDocumentCollection())) {
+            caseData.setDocumentCollection(new ArrayList<>());
         }
+
+        caseData.getDocumentCollection().add(TseAdminHelper.getDocumentTypeItem(documentManagementService,
+                tornadoService, caseDetails, userToken, TSE_REPLY, RESPONDENT_CORRESPONDENCE));
     }
 
     /**
@@ -247,7 +237,8 @@ public class TseRespondentReplyService {
         }
 
         try {
-            byte[] bytes = tornadoService.generateEventDocumentBytes(caseData, "", "TSE Reply.pdf");
+            byte[] bytes = tornadoService.generateEventDocumentBytes(caseData, "",
+                    "TSE Reply.pdf");
             String claimantEmail = caseData.getClaimantType().getClaimantEmailAddress();
             Map<String, Object> personalisation = TseHelper.getPersonalisationForResponse(caseDetails,
                     bytes, emailService.getCitizenCaseLink(caseDetails.getCaseId()));

--- a/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
+++ b/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
@@ -13,11 +13,8 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
-import uk.gov.hmcts.et.common.model.ccd.types.UploadedDocumentType;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
 
@@ -55,32 +52,10 @@ public class TseAdminControllerFunctionalTest extends BaseFunctionalTest {
         caseData.setResTseCopyToOtherPartyYesOrNo(NO);
         caseData.setRespondentCollection(new ArrayList<>(Collections.singletonList(createRespondentType())));
         caseData.setGenericTseApplicationCollection(createApplicationCollection());
-
         DynamicValueType dvt = DynamicValueType.create(APPLICATION_CODE, APPLICATION_LABEL);
         DynamicFixedListType dynamicFixedListType = DynamicFixedListType.of(dvt);
         dynamicFixedListType.setListItems(List.of(dvt));
         caseData.setTseAdminSelectApplication(dynamicFixedListType);
-
-        caseData.setTseAdminTableMarkUp("|Application||\r\n|--|--|\r\n|||\r\n|||\r\n|Applicant|Respondent");
-        caseData.setTseAdmReplyEnterResponseTitle("test title");
-        caseData.setTseAdminAdditionalInformation("test info");
-        caseData.setTseAdminDecision("Granted");
-        caseData.setTseAdminTypeOfDecision("Case management order");
-        caseData.setTseAdminIsResponseRequired("Yes");
-        caseData.setTseAdminSelectPartyRespond("Both parties");
-        GenericTypeItem<DocumentType> genericTypeItem = new GenericTypeItem<>();
-        genericTypeItem.setId("1");
-
-        UploadedDocumentType uploadedDocumentType = new UploadedDocumentType();
-        uploadedDocumentType.setDocumentFilename("test file name");
-        uploadedDocumentType.setDocumentBinaryUrl("");
-        uploadedDocumentType.setDocumentUrl("");
-
-        DocumentType documentType = new DocumentType();
-        documentType.setUploadedDocument(uploadedDocumentType);
-        documentType.setShortDescription("test description");
-        genericTypeItem.setValue(documentType);
-        caseData.setTseAdminResponseRequiredYesDoc(List.of(genericTypeItem));
 
         ccdRequest = CCDRequestBuilder.builder()
             .withCaseData(caseData)

--- a/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
+++ b/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
@@ -13,8 +13,11 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
+import uk.gov.hmcts.et.common.model.ccd.types.UploadedDocumentType;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
 
@@ -52,10 +55,32 @@ public class TseAdminControllerFunctionalTest extends BaseFunctionalTest {
         caseData.setResTseCopyToOtherPartyYesOrNo(NO);
         caseData.setRespondentCollection(new ArrayList<>(Collections.singletonList(createRespondentType())));
         caseData.setGenericTseApplicationCollection(createApplicationCollection());
+
         DynamicValueType dvt = DynamicValueType.create(APPLICATION_CODE, APPLICATION_LABEL);
         DynamicFixedListType dynamicFixedListType = DynamicFixedListType.of(dvt);
         dynamicFixedListType.setListItems(List.of(dvt));
         caseData.setTseAdminSelectApplication(dynamicFixedListType);
+
+        caseData.setTseAdminTableMarkUp("|Application||\r\n|--|--|\r\n|||\r\n|||\r\n|Applicant|Respondent");
+        caseData.setTseAdmReplyEnterResponseTitle("test title");
+        caseData.setTseAdminAdditionalInformation("test info");
+        caseData.setTseAdminDecision("Granted");
+        caseData.setTseAdminTypeOfDecision("Case management order");
+        caseData.setTseAdminIsResponseRequired("Yes");
+        caseData.setTseAdminSelectPartyRespond("Both parties");
+        GenericTypeItem<DocumentType> genericTypeItem = new GenericTypeItem<>();
+        genericTypeItem.setId("1");
+
+        UploadedDocumentType uploadedDocumentType = new UploadedDocumentType();
+        uploadedDocumentType.setDocumentFilename("test file name");
+        uploadedDocumentType.setDocumentBinaryUrl("");
+        uploadedDocumentType.setDocumentUrl("");
+
+        DocumentType documentType = new DocumentType();
+        documentType.setUploadedDocument(uploadedDocumentType);
+        documentType.setShortDescription("test description");
+        genericTypeItem.setValue(documentType);
+        caseData.setTseAdminResponseRequiredYesDoc(List.of(genericTypeItem));
 
         ccdRequest = CCDRequestBuilder.builder()
             .withCaseData(caseData)

--- a/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
+++ b/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
@@ -52,9 +52,10 @@ public class TseAdminControllerFunctionalTest extends BaseFunctionalTest {
         caseData.setResTseCopyToOtherPartyYesOrNo(NO);
         caseData.setRespondentCollection(new ArrayList<>(Collections.singletonList(createRespondentType())));
         caseData.setGenericTseApplicationCollection(createApplicationCollection());
-        caseData.setTseAdminSelectApplication(
-            DynamicFixedListType.of(
-                DynamicValueType.create(APPLICATION_CODE, APPLICATION_LABEL)));
+        DynamicValueType dvt = DynamicValueType.create(APPLICATION_CODE, APPLICATION_LABEL);
+        DynamicFixedListType dynamicFixedListType = DynamicFixedListType.of(dvt);
+        dynamicFixedListType.setListItems(List.of(dvt));
+        caseData.setTseAdminSelectApplication(dynamicFixedListType);
 
         ccdRequest = CCDRequestBuilder.builder()
             .withCaseData(caseData)

--- a/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
+++ b/src/test/apiTest/java/uk/gov/hmcts/ethos/replacement/apitest/TseAdminControllerFunctionalTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
+import static uk.gov.hmcts.ecm.common.model.helper.Constants.OPEN_STATE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.TSE_APP_AMEND_RESPONSE;
 
 @Slf4j
@@ -157,6 +158,7 @@ public class TseAdminControllerFunctionalTest extends BaseFunctionalTest {
     private List<GenericTseApplicationTypeItem> createApplicationCollection() {
         GenericTseApplicationType respondentTseType = new GenericTseApplicationType();
         respondentTseType.setNumber(APPLICATION_CODE);
+        respondentTseType.setStatus(OPEN_STATE);
 
         GenericTseApplicationTypeItem tseApplicationTypeItem = new GenericTseApplicationTypeItem();
         tseApplicationTypeItem.setId(UUID.randomUUID().toString());

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
@@ -78,11 +78,12 @@ class TseAdminHelperTest {
         assertThat(actual.getListItems().size(), is(1));
     }
 
-
     @Test
-    void getDocumentTypeItem_returns_null_for_emptyCaseDetails() {
+    void getDocumentTypeItem_returnsNullForEmptyCaseDetails() {
+        CaseDetails caseDetails = null;
         DocumentTypeItem actual  = TseAdminHelper.getDocumentTypeItem(documentManagementService, tornadoService,
-                null, "testToken", "docType", "correspondenceType");
+                caseDetails, "testToken", "docType",
+                "correspondenceType");
         assertNull(actual);
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT_TITLE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.OPEN_STATE;
@@ -113,7 +115,7 @@ class TseAdminHelperTest {
         String actual  = TseAdminHelper.getReplyDocumentRequest(caseData, "testAccessKey");
 
         assertNotNull(actual);
-        assertNotNull(actual.contains("EM-TRB-EGW-ENG-Admin-Tse-Reply.docx"));
+        assertThat(actual.contains("EM-TRB-EGW-ENG-000991.docx"), is(Boolean.TRUE));
     }
 
     @Test
@@ -122,7 +124,7 @@ class TseAdminHelperTest {
         String actual  = TseAdminHelper.getAdminDecisionDocumentRequest(caseData, "testAccessKey");
 
         assertNotNull(actual);
-        assertNotNull(actual.contains("EM-TRB-EGW-ENG-Admin-Tse-Decision.docx"));
+        assertThat(actual.contains("EM-TRB-EGW-ENG-000992.docx"), is(Boolean.TRUE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
@@ -28,8 +28,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT_TITLE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.OPEN_STATE;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/TseAdminHelperTest.java
@@ -1,28 +1,44 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.helpers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
+import uk.gov.hmcts.et.common.model.bulk.types.DynamicValueType;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
+import uk.gov.hmcts.et.common.model.ccd.DocumentInfo;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationType;
 import uk.gov.hmcts.et.common.model.ccd.items.GenericTseApplicationTypeItem;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentManagementService;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
 import uk.gov.hmcts.ethos.utils.TseApplicationBuilder;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.CLAIMANT_TITLE;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.OPEN_STATE;
 
 @ExtendWith(SpringExtension.class)
 class TseAdminHelperTest {
     private CaseData caseData;
+    @MockBean
+    private DocumentManagementService documentManagementService;
+    @MockBean
+    private TornadoService tornadoService;
 
     @BeforeEach
     public void setUp() {
@@ -60,5 +76,71 @@ class TseAdminHelperTest {
     void populateSelectApplicationAdminDropdown_withAnApplication_returnsDynamicList() {
         DynamicFixedListType actual = TseAdminHelper.populateSelectApplicationAdminDropdown(caseData);
         assertThat(actual.getListItems().size(), is(1));
+    }
+
+
+    @Test
+    void getDocumentTypeItem_returns_null_for_emptyCaseDetails() {
+        DocumentTypeItem actual  = TseAdminHelper.getDocumentTypeItem(documentManagementService, tornadoService,
+                null, "testToken", "docType", "correspondenceType");
+        assertNull(actual);
+    }
+
+    @Test
+    void getDocumentTypeItem_returns_documentTypeItem_for_initialised_caseDetails() throws IOException {
+        CaseDetails caseDetails = new CaseDetails();
+        String selectedTseApp = "testSelectedResTseApplication";
+        String documentType = "docType";
+        caseData.setResTseSelectApplication(selectedTseApp);
+        caseDetails.setCaseData(caseData);
+        DocumentInfo expectedDocumentInfo = new DocumentInfo();
+        expectedDocumentInfo.setDescription(documentType);
+        String correspondenceType = "correspondenceType";
+
+        when(tornadoService.generateEventDocument(any(), any(), any(), any())).thenReturn(expectedDocumentInfo);
+        DocumentTypeItem actual  = TseAdminHelper.getDocumentTypeItem(documentManagementService, tornadoService,
+                caseDetails, "testToken", documentType, correspondenceType);
+
+        assertNotNull(actual);
+        assertThat(actual.getValue().getTypeOfDocument(), is(correspondenceType));
+        assertThat(actual.getValue().getShortDescription(), is(selectedTseApp));
+    }
+
+    @Test
+    void getReplyDocumentRequest_Returns_doc_as_String() throws JsonProcessingException {
+        caseData.setTseAdminSelectApplication(getTseAdminSelectApp());
+        String actual  = TseAdminHelper.getReplyDocumentRequest(caseData, "testAccessKey");
+
+        assertNotNull(actual);
+        assertNotNull(actual.contains("EM-TRB-EGW-ENG-Admin-Tse-Reply.docx"));
+    }
+
+    @Test
+    void getAdminDecisionDocumentRequest_returns_admin_doc_request_as_string() throws JsonProcessingException {
+        caseData.setTseAdminSelectApplication(getTseAdminSelectApp());
+        String actual  = TseAdminHelper.getAdminDecisionDocumentRequest(caseData, "testAccessKey");
+
+        assertNotNull(actual);
+        assertNotNull(actual.contains("EM-TRB-EGW-ENG-Admin-Tse-Decision.docx"));
+    }
+
+    @Test
+    void getTseAdminSelectedApplicationType_returns_selected_application() {
+        caseData.setTseAdminSelectApplication(getTseAdminSelectApp());
+        String expectedTseAppNumber = caseData.getGenericTseApplicationCollection().get(0).getValue().getNumber();
+        GenericTseApplicationType actual  = TseAdminHelper.getTseAdminSelectedApplicationType(caseData);
+
+        assertNotNull(actual);
+        assertThat(actual.getNumber(), is(expectedTseAppNumber));
+    }
+
+    private static DynamicFixedListType getTseAdminSelectApp() {
+        DynamicFixedListType flt = new DynamicFixedListType();
+        DynamicValueType dvt = new DynamicValueType();
+        dvt.setLabel("test");
+        dvt.setCode("1");
+        flt.setValue(dvt);
+        flt.setValue(dvt);
+        return flt;
     }
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseAdminServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseAdminServiceTest.java
@@ -68,6 +68,10 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 class TseAdminServiceTest {
     private TseAdminService tseAdminService;
     private EmailService emailService;
+    @MockBean
+    private DocumentManagementService documentManagementService;
+    @MockBean
+    private TornadoService tornadoService;
 
     @MockBean
     private TseService tseService;
@@ -97,11 +101,25 @@ class TseAdminServiceTest {
     @BeforeEach
     void setUp() {
         emailService = spy(new TestEmailService());
-        tseAdminService = new TseAdminService(emailService, tseService);
+        tseAdminService = new TseAdminService(emailService, tseService, documentManagementService, tornadoService);
         ReflectionTestUtils.setField(tseAdminService, "tseAdminRecordClaimantTemplateId", TEMPLATE_ID);
         ReflectionTestUtils.setField(tseAdminService, "tseAdminRecordRespondentTemplateId", TEMPLATE_ID);
 
         caseData = CaseDataBuilder.builder().build();
+    }
+
+    @Test
+    void addsTseAdminDecisionPdfToDocCollection() {
+        caseData.setEthosCaseReference(CASE_NUMBER);
+        caseData.setTseAdmReplyIsCmoOrRequest("Case management order");
+        caseData.setTseAdmReplyCmoIsResponseRequired("Yes");
+        caseData.setTseAdmReplyCmoSelectPartyRespond("Both");
+        CaseDetails caseDetails = new CaseDetails();
+        caseDetails.setCaseData(caseData);
+        caseDetails.setCaseId(CASE_ID);
+
+        tseAdminService.addTseAdminDecisionPdfToDocCollection(caseDetails, "test token");
+        assertThat(caseData.getDocumentCollection()).isNotNull();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseRespondentReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TseRespondentReplyServiceTest.java
@@ -256,8 +256,7 @@ class TseRespondentReplyServiceTest {
         caseDetails.setCaseId("caseId");
         caseDetails.setCaseData(caseData);
 
-        tseRespondentReplyService.addTseRespondentReplyPdfToDocCollection(caseData, "testUserToken",
-                "ET_EnglandWales");
+        tseRespondentReplyService.addTseRespondentReplyPdfToDocCollection(caseDetails, "testUserToken");
 
         assertThat(caseData.getDocumentCollection().size(), is(1));
         assertThat(caseData.getDocumentCollection().get(0).getValue().getTypeOfDocument(),


### PR DESCRIPTION
The code changes consist an implementation of [RET-3891](https://tools.hmcts.net/jira/browse/RET-3891) The current implementation covers pdf generation of "Tse Admin Reply" and "Tse Admin Decision Record" actions by Caseworkers.

Because of increasing complexity, the functionality of attaching the pdf generated (by the two Admin actions above) to emails being sent to the Claimant and/or Respondent is separated out to [RET-4189](https://tools.hmcts.net/jira/browse/RET-4189).



Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[X] No



