### PR TITLE
Remove search criteria update in global search migration

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationController.java
@@ -60,7 +60,6 @@ public class GlobalSearchDataMigrationController {
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
 
         caseManagementForCaseWorkerService.setGlobalSearchDefaults(caseData);
-        caseManagementForCaseWorkerService.setSearchCriteria(caseData);
         log.info("Migrating existing case: {} for caseManagementCategory: {},  caseNameHmctsInternal: {},"
                         + "  caseManagementLocation: {}",
                 ccdRequest.getCaseDetails().getCaseTypeId(),

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -13,28 +13,20 @@ import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.exceptions.CaseCreationException;
 import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
-import uk.gov.hmcts.et.common.model.ccd.Address;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
-import uk.gov.hmcts.et.common.model.ccd.SearchCriteria;
-import uk.gov.hmcts.et.common.model.ccd.SearchParty;
 import uk.gov.hmcts.et.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.et.common.model.ccd.items.DateListedTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.EccCounterClaimTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.items.GenericTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.HearingTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.items.ListTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.CaseLocation;
-import uk.gov.hmcts.et.common.model.ccd.types.ClaimantIndType;
-import uk.gov.hmcts.et.common.model.ccd.types.ClaimantType;
 import uk.gov.hmcts.et.common.model.ccd.types.DateListedType;
 import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
 import uk.gov.hmcts.et.common.model.ccd.types.EccCounterClaimType;
 import uk.gov.hmcts.et.common.model.ccd.types.HearingType;
-import uk.gov.hmcts.et.common.model.ccd.types.RepresentedTypeR;
 import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.tribunaloffice.CourtLocations;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.ECCHelper;
@@ -591,73 +583,6 @@ public class CaseManagementForCaseWorkerService {
 
     private void setCaseManagementCategory(CaseData caseData) {
         caseData.setCaseManagementCategory(DynamicFixedListType.from("Employment Tribunals", "Employment", true));
-    }
-
-    public void setSearchCriteria(CaseData caseData) {
-        if (!featureToggleService.isGlobalSearchEnabled()) {
-            return;
-        }
-
-        ListTypeItem<SearchParty> searchParties = new ListTypeItem<>();
-        ClaimantIndType claimantIndType = caseData.getClaimantIndType();
-
-        if (claimantIndType != null) {
-            ClaimantType claimantType = caseData.getClaimantType();
-
-            Address claimantAddressUK = claimantType.getClaimantAddressUK();
-            searchParties.add(GenericTypeItem.from(SearchParty.builder()
-                    .name(claimantIndType.claimantFullName())
-                    .dateOfBirth(claimantIndType.getClaimantDateOfBirth())
-                    .emailAddress(claimantType.getClaimantEmailAddress())
-                    .addressLine1(claimantAddressUK.getAddressLine1())
-                    .postCode(claimantAddressUK.getPostCode())
-                    .build()));
-        }
-
-        if (caseData.getRespondentCollection() != null) {
-            caseData.getRespondentCollection().forEach(respondent -> {
-                RespondentSumType respondentValue = respondent.getValue();
-                Address respondentAddress = respondentValue.getResponseRespondentAddress();
-
-                SearchParty.SearchPartyBuilder searchPartyBuilder = SearchParty.builder()
-                        .name(respondentValue.getRespondentName())
-                        .emailAddress(respondentValue.getRespondentEmail());
-
-                if (respondentAddress != null) {
-                    searchPartyBuilder
-                            .addressLine1(respondentAddress.getAddressLine1())
-                            .postCode(respondentAddress.getPostCode());
-                }
-                searchParties.add(GenericTypeItem.from(searchPartyBuilder.build()));
-            });
-        }
-
-        if (caseData.getRepCollection() != null) {
-            caseData.getRepCollection().forEach(rep -> {
-                RepresentedTypeR repValue = rep.getValue();
-                Address representativeAddress = repValue.getRepresentativeAddress();
-
-                SearchParty.SearchPartyBuilder searchRepPartyBuilder = SearchParty.builder()
-                        .name(repValue.getRespRepName())
-                        .emailAddress(repValue.getRepresentativeEmailAddress());
-
-                if (representativeAddress != null) {
-                    searchRepPartyBuilder
-                            .addressLine1(representativeAddress.getAddressLine1())
-                            .postCode(representativeAddress.getPostCode());
-                }
-                searchParties.add(GenericTypeItem.from(searchRepPartyBuilder.build()));
-            });
-        }
-
-        ListTypeItem<String> otherCaseReferences = new ListTypeItem<>();
-        otherCaseReferences.add(GenericTypeItem.from(caseData.getEthosCaseReference()));
-        SearchCriteria searchCriteria = SearchCriteria.builder()
-                .otherCaseReferences(otherCaseReferences)
-                .searchParties(searchParties)
-                .build();
-        caseData.setSearchCriteria(searchCriteria);
-
     }
 
     private void setCaseManagementLocation(CaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationControllerTest.java
@@ -76,7 +76,6 @@ class GlobalSearchDataMigrationControllerTest {
                 .andExpect(jsonPath(JsonMapper.WARNINGS, nullValue()));
 
         verify(caseManagementForCaseWorkerService).setGlobalSearchDefaults(any(CaseData.class));
-        verify(caseManagementForCaseWorkerService).setSearchCriteria(any(CaseData.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerServiceTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.et.common.model.ccd.Address;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
-import uk.gov.hmcts.et.common.model.ccd.SearchCriteria;
 import uk.gov.hmcts.et.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.et.common.model.ccd.items.DateListedTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
@@ -58,7 +57,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -258,18 +256,6 @@ class CaseManagementForCaseWorkerServiceTest {
         CaseData caseData = scotlandCcdRequest1.getCaseDetails().getCaseData();
         caseManagementForCaseWorkerService.caseDataDefaults(caseData);
         assertEquals("Anton Juliet Rodriguez vs Antonio Vazquez", caseData.getCaseNameHmctsInternal());
-    }
-
-    @Test
-    void addSearchCriteriaInCaseData() {
-        CaseData caseData = ccdRequest2.getCaseDetails().getCaseData();
-        caseManagementForCaseWorkerService.setSearchCriteria(caseData);
-        SearchCriteria searchCriteria = caseData.getSearchCriteria();
-        assertNotNull(searchCriteria);
-        assertEquals("123456", searchCriteria.getOtherCaseReferences().get(0).getValue());
-        assertEquals("Mr A Rodriguez", searchCriteria.getSearchParties().get(0).getValue().getName());
-        assertEquals("Antonio Vazquez", searchCriteria.getSearchParties().get(1).getValue().getName());
-        assertEquals("RepresentativeNameRespondent", searchCriteria.getSearchParties().get(2).getValue().getName());
     }
 
     @Test


### PR DESCRIPTION
CCD populates search criteria field on any event call on case data and later add search criteria data in index, so our implementation was wrong, so reverting