### PR TITLE
RET-4379: Dynamic URL for noc-claimant email

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
@@ -63,12 +63,14 @@ public final class NocNotificationHelper {
 
     }
 
-    public static Map<String, String> buildPersonalisationWithPartyName(CaseDetails caseDetails, String partyName) {
+    public static Map<String, String> buildPersonalisationWithPartyName(CaseDetails caseDetails, String partyName,
+                                                                        String citUrl) {
         Map<String, String> personalisation = new ConcurrentHashMap<>();
 
         addCommonValues(caseDetails.getCaseData(), personalisation);
         personalisation.put("party_name", partyName);
         personalisation.put("ccdId", caseDetails.getCaseId());
+        personalisation.put("linkToCitUI", citUrl);
 
         return personalisation;
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelper.java
@@ -64,13 +64,13 @@ public final class NocNotificationHelper {
     }
 
     public static Map<String, String> buildPersonalisationWithPartyName(CaseDetails caseDetails, String partyName,
-                                                                        String citUrl) {
+                                                                        String linkToCitUI) {
         Map<String, String> personalisation = new ConcurrentHashMap<>();
 
         addCommonValues(caseDetails.getCaseData(), personalisation);
         personalisation.put("party_name", partyName);
         personalisation.put("ccdId", caseDetails.getCaseId());
-        personalisation.put("linkToCitUI", citUrl);
+        personalisation.put("linkToCitUI", linkToCitUI);
 
         return personalisation;
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NotificationHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NotificationHelper.java
@@ -127,7 +127,7 @@ public final class NotificationHelper {
         return representativeClaimantType.getNameOfRepresentative();
     }
 
-    private static String getEmailAddressForClaimant(CaseData caseData) {
+    public static String getEmailAddressForClaimant(CaseData caseData) {
         RepresentedTypeC representativeClaimantType = caseData.getRepresentativeClaimantType();
 
         if (representativeClaimantType == null || NO.equals(caseData.getClaimantRepresentedQuestion())) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocNotificationHelper.buildPersonalisationWithPartyName;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocNotificationHelper.buildPreviousRespondentSolicitorPersonalisation;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.NocNotificationHelper.buildRespondentPersonalisation;
 
 /**
@@ -119,11 +120,8 @@ public class NocNotificationService {
             return;
         }
 
-        emailService.sendEmail(
-                previousRespondentSolicitorTemplateId,
-                oldOrgAdminEmail,
-                NocNotificationHelper.buildPreviousRespondentSolicitorPersonalisation(caseDataPrevious)
-        );
+        Map<String, String> personalisation = buildPreviousRespondentSolicitorPersonalisation(caseDataPrevious);
+        emailService.sendEmail(previousRespondentSolicitorTemplateId, oldOrgAdminEmail, personalisation);
     }
 
     private void sendEmailToNewOrgAdmin(String orgId, CaseDetails caseDetailsNew, String partyName) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
@@ -115,7 +115,7 @@ public class NocNotificationService {
 
         String oldOrgAdminEmail = resBody.getSuperUser().getEmail();
         if (isNullOrEmpty(oldOrgAdminEmail)) {
-            log.warn("Previous Org " + orgId + " is missing org admin email");
+            log.warn("Previous Org {} is missing org admin email", orgId);
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationService.java
@@ -51,10 +51,11 @@ public class NocNotificationService {
         if (isNullOrEmpty(claimantEmail)) {
             log.warn("missing claimantEmail");
         } else {
+            String citUrl = emailService.getCitizenCaseLink(caseDetailsNew.getCaseId());
             emailService.sendEmail(
                     claimantTemplateId,
                     claimantEmail,
-                    NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsPrevious, partyName)
+                    NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsPrevious, partyName, citUrl)
             );
         }
 
@@ -122,10 +123,11 @@ public class NocNotificationService {
                 if (isNullOrEmpty(newOrgAdminEmail)) {
                     log.warn("New Org " + orgId + " is missing org admin email");
                 } else {
+                    String citUrl = emailService.getCitizenCaseLink(caseDetailsNew.getCaseId());
                     emailService.sendEmail(
                             newRespondentSolicitorTemplateId,
                             newOrgAdminEmail,
-                            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsNew, partyName)
+                            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetailsNew, partyName, citUrl)
                     );
                 }
             }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/NocNotificationHelperTest.java
@@ -89,9 +89,10 @@ class NocNotificationHelperTest {
 
     @Test
     void testbuildClaimantPersonalisation() {
+        String citLink = "http://domain/citizen-hub/1234";
         Map<String, String> claimantPersonalisation =
-            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party");
-        assertThat(claimantPersonalisation.size(), is(5));
+            NocNotificationHelper.buildPersonalisationWithPartyName(caseDetails, "test_party", citLink);
+        assertThat(claimantPersonalisation.size(), is(6));
         assertThat(claimantPersonalisation.get("party_name"), is("test_party"));
         assertThat(claimantPersonalisation.get("ccdId"), is("1234"));
         assertThat(claimantPersonalisation.get("claimant"), is("Claimant LastName"));
@@ -99,6 +100,7 @@ class NocNotificationHelperTest {
                 is("Respondent Respondent Unrepresented Respondent Represented Respondent")
         );
         assertThat(claimantPersonalisation.get("case_number"), is("12345/6789"));
+        assertThat(claimantPersonalisation.get("linkToCitUI"), is(citLink));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/NocNotificationServiceTest.java
@@ -137,6 +137,7 @@ class NocNotificationServiceTest {
         respondentSumType.setRespondentName("Respondent");
         respondentSumType.setRespondentEmail("res@rep.com");
         when(nocRespondentHelper.getRespondent(any(), any())).thenReturn(respondentSumType);
+        when(emailService.getCitizenCaseLink(any())).thenReturn("http://domain/citizen-hub/1234");
         nocNotificationService.sendNotificationOfChangeEmails(
                 caseDetailsBefore,
                 caseDetailsNew,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-4379

### Change description ###

Dynamic URL for noc-claimant email. The test template has been changed to reflect this, production template pending change. This code still sends `ccdId` as well as the new variable so it will work with the current template in production

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
