### PR TITLE
add ET3 response support docs to doc tab

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3ResponseController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3ResponseController.java
@@ -175,6 +175,7 @@ public class Et3ResponseController {
 
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
         Et3ResponseHelper.addEt3DataToRespondent(caseData, ccdRequest.getEventId());
+        et3ResponseService.saveRelatedDocumentsToDocumentCollection(caseData);
         Et3ResponseHelper.resetEt3FormFields(caseData);
         return getCallbackRespEntityNoErrors(caseData);
     }

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/Et3ResponseService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/Et3ResponseService.java
@@ -128,7 +128,9 @@ public class Et3ResponseService {
             documentTypeItem.getValue().setTypeOfDocument(ET3_ATTACHMENT);
         }
 
-        documents.addAll(documentList);
+        if (!documentList.isEmpty()) {
+            documents.addAll(documentList);
+        }
 
         if (caseData.getEt3ResponseEmployerClaimDocument() != null) {
             documents.add(createDocumentTypeItem(caseData.getEt3ResponseEmployerClaimDocument(), ET3_ATTACHMENT));


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RET-4761


### Change description ###
Code change to add ET3 response support docs to the case documents tab

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
