### PR TITLE
RET-0000: Added methods to TornadoService to enable reducing tight coupling

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TornadoDocument.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/domain/documents/TornadoDocument.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.domain.documents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TornadoDocument<T> {
+    @JsonProperty("accessKey")
+    private String accessKey;
+    @JsonProperty("templateName")
+    private String templateName;
+    @JsonProperty("outputName")
+    private String outputName;
+    @JsonProperty("data")
+    private T data;
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TornadoServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/TornadoServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.et.common.model.multiples.MultipleData;
 import uk.gov.hmcts.ethos.replacement.docmosis.config.OAuth2Configuration;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.TokenRequest;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.TokenResponse;
+import uk.gov.hmcts.ethos.replacement.docmosis.domain.documents.TornadoDocument;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.HelperTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.SignificantItemType;
 import uk.gov.hmcts.ethos.replacement.docmosis.idam.IdamApi;
@@ -286,6 +287,17 @@ class TornadoServiceTest {
                 ENGLANDWALES_CASE_TYPE_ID,
                 INITIAL_CONSIDERATION_PDF);
         assertThat(bytes.length, is(0));
+    }
+
+    @Test
+    void generateDocument_success() throws IOException {
+        mockConnectionSuccess();
+        var document = TornadoDocument.builder().templateName("template.docx").data(DOCUMENT_INFO_MARKUP).build();
+        DocumentInfo documentInfo = tornadoService.generateDocument(
+            AUTH_TOKEN, document, INITIAL_CONSIDERATION_PDF, ENGLANDWALES_CASE_TYPE_ID);
+
+        verifyDocumentInfo(documentInfo);
+        assertEquals(INITIAL_CONSIDERATION_PDF, documentInfo.getDescription());
     }
 
     private void createUserService() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-0000

### Change description ###

TornadoService is tightly coupled with a lot of other classes. To generate a document a class currently has to call out to TornadoService, which in turn can call out to many other classes to fetch the data it needs.

Instead, TornadoService's purpose should only be to talk to Tornado and turn a caller's business data into a document. 

This change is intended to be made use of in future tickets with Multiple Referral. Separate PRs can be made to refactor existing code

Example usage: 

```java
    public static DocumentInfo generateReferralDocument(MultipleData caseData, CaseData leadCase) {
        TornadoDocument<ReferralTypeData> document = getDocumentRequest(caseData, leadCase);
        return tornadoService.generateDocument(userToken, document , "Referral Summary.pdf", caseTypeId);
    }

    public static TornadoDocument getDocumentRequest(MultipleData caseData, CaseData leadCase) {
        ReferralTypeData data;
        if (caseData.getReferentEmail() != null || caseData.getSelectReferral() == null) {
            data = newReferralRequest(caseData, leadCase);
        } else {
            data = existingReferralRequest(caseData, leadCase);
        }

        return TornadoDocument.<ReferralTypeData>builder()
            .outputName(REF_OUTPUT_NAME)
            .templateName(REF_SUMMARY_TEMPLATE_NAME)
            .data(data).build();
    }
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
