### PR TITLE
RET-0000: Added request interceptor for token verify service

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/WebConfig.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/WebConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
 import uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors.RequestInterceptor;
 
 /**

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/WebConfig.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/WebConfig.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors.RequestInterceptor;
+
+/**
+ * Configures the API to add intercepters for calls from external sources.
+ */
+@Component
+public class WebConfig implements WebMvcConfigurer {
+    private final RequestInterceptor requestInterceptor;
+
+    @Autowired
+    public WebConfig(RequestInterceptor requestInterceptor) {
+        this.requestInterceptor = requestInterceptor;
+    }
+
+    /**
+     * This config excludes certain urls to the inteceptor.
+     * these are endpoints that do not require authentication
+     * @param registry {@link InterceptorRegistry} in which the exclusions for the inteceptor are added
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(requestInterceptor)
+            .excludePathPatterns(
+                "/health",
+                "/webjars/springfox-swagger-ui/**",
+                "/swagger-ui/**",
+                "/swagger-resources/**",
+                "/v2/**",
+                "/favicon.ico",
+                "/health",
+                "/mappings",
+                "/info",
+                "/metrics",
+                "/metrics/**",
+                "/v3/**",
+                "/"
+            );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/interceptors/RequestInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/interceptors/RequestInterceptor.java
@@ -1,18 +1,16 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import java.io.IOException;
 
 /**
  * Intercepts any call and validates the token.
@@ -32,18 +30,17 @@ public class RequestInterceptor implements HandlerInterceptor {
 
     /**
      * Intercepts any incoming calls and throws exception if token is invalid.
-     * @param requestServlet current HTTP request
-     * @param responseServlet current HTTP response
-     * @param handler chosen handler to execute, for type and/or instance evaluation
+     * @param request current HTTP request
+     * @param response current HTTP response
+     * @param hnd chosen handler to execute, for type and/or instance evaluation
      * @return true if the token is verified
-     * @throws IOException 
      */
     @Override
-    public boolean preHandle(HttpServletRequest requestServlet, HttpServletResponse responseServlet, Object handler) throws IOException {
-        String authorizationHeader = requestServlet.getHeader(AUTHORIZATION);
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object hnd) throws IOException {
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
         if (!verifyTokenService.verifyTokenSignature(authorizationHeader)) {
             log.error(FAILED_TO_VERIFY_TOKEN, authorizationHeader);
-            responseServlet.sendError(HttpServletResponse.SC_FORBIDDEN, "Failed to verify bearer token.");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Failed to verify bearer token.");
             return false;
         }
 

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/interceptors/RequestInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/interceptors/RequestInterceptor.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors;
+
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import java.io.IOException;
+
+/**
+ * Intercepts any call and validates the token.
+ */
+@Slf4j
+@Component
+public class RequestInterceptor implements HandlerInterceptor {
+
+    private static final String FAILED_TO_VERIFY_TOKEN = "Failed to verify the following token: {}";
+
+    private final VerifyTokenService verifyTokenService;
+
+    @Autowired
+    public RequestInterceptor(VerifyTokenService verifyTokenService) {
+        this.verifyTokenService = verifyTokenService;
+    }
+
+    /**
+     * Intercepts any incoming calls and throws exception if token is invalid.
+     * @param requestServlet current HTTP request
+     * @param responseServlet current HTTP response
+     * @param handler chosen handler to execute, for type and/or instance evaluation
+     * @return true if the token is verified
+     * @throws IOException 
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest requestServlet, HttpServletResponse responseServlet, Object handler) throws IOException {
+        String authorizationHeader = requestServlet.getHeader(AUTHORIZATION);
+        if (!verifyTokenService.verifyTokenSignature(authorizationHeader)) {
+            log.error(FAILED_TO_VERIFY_TOKEN, authorizationHeader);
+            responseServlet.sendError(HttpServletResponse.SC_FORBIDDEN, "Failed to verify bearer token.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/config/RequestInterceptorTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/config/RequestInterceptorTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.config;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors.RequestInterceptor;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+class RequestInterceptorTest {
+
+    @Mock
+    private VerifyTokenService verifyTokenService;
+
+    private RequestInterceptor requestInterceptor;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        requestInterceptor = new RequestInterceptor(verifyTokenService);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void preHandle_ValidToken_ReturnsTrue() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(anyString())).thenReturn(true);
+
+        request.addHeader(AUTHORIZATION, "");
+        boolean result = requestInterceptor.preHandle(request, response, new Object());
+
+        assertTrue(result);
+    }
+
+    @Test
+    void preHandle_InvalidToken_ReturnsFalseAndSetsErrorResponse() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(anyString())).thenReturn(false);
+
+        boolean result = requestInterceptor.preHandle(request, response, new Object());
+
+        assertFalse(result);
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+        assertEquals("Failed to verify bearer token.", response.getErrorMessage());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/config/RequestInterceptorTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/config/RequestInterceptorTest.java
@@ -1,16 +1,15 @@
 package uk.gov.hmcts.ethos.replacement.docmosis.config;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
 import uk.gov.hmcts.ethos.replacement.docmosis.config.interceptors.RequestInterceptor;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+
+import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BaseControllerTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
+import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(BulkActionsController.class)
+@ContextConfiguration(classes = DocmosisApplication.class)
+public class BaseControllerTest {
+    public static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+
+    @MockBean
+    public VerifyTokenService verifyTokenService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BulkActionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BulkActionsControllerTest.java
@@ -34,7 +34,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.BulkSearchService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.BulkUpdateService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentGenerationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.SubMultipleService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -62,9 +61,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(BulkActionsController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class BulkActionsControllerTest {
+class BulkActionsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String CREATION_BULK_URL = "/createBulk";
     private static final String CREATION_BULK_ES_URL = "/createBulkES";
     private static final String SEARCH_BULK_URL = "/searchBulk";
@@ -106,9 +104,6 @@ class BulkActionsControllerTest {
     @MockBean
     private SubMultipleService subMultipleService;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
-
     private MockMvc mvc;
     private JsonNode requestContent;
     private BulkCasesPayload bulkCasesPayload;
@@ -122,7 +117,9 @@ class BulkActionsControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         List<SubmitEvent> submitEvents;
@@ -527,6 +524,7 @@ class BulkActionsControllerTest {
 
     @Test
     void createBulkCaseError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(CREATION_BULK_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -536,6 +534,7 @@ class BulkActionsControllerTest {
 
     @Test
     void createBulkCaseESError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(CREATION_BULK_ES_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -545,6 +544,7 @@ class BulkActionsControllerTest {
 
     @Test
     void createSearchBulkCaseError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(SEARCH_BULK_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -554,6 +554,7 @@ class BulkActionsControllerTest {
 
     @Test
     void midSearchBulkCaseError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(MID_SEARCH_BULK_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -563,6 +564,7 @@ class BulkActionsControllerTest {
 
     @Test
     void updateBulkError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(UPDATE_BULK_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -572,6 +574,7 @@ class BulkActionsControllerTest {
 
     @Test
     void updateBulkCaseError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(UPDATE_BULK_CASE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -581,6 +584,7 @@ class BulkActionsControllerTest {
 
     @Test
     void generateBulkLetterError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(GENERATE_BULK_LETTER_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -590,6 +594,7 @@ class BulkActionsControllerTest {
 
     @Test
     void midCreateSubMultipleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(MID_CREATE_SUB_MULTIPLE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -599,6 +604,7 @@ class BulkActionsControllerTest {
 
     @Test
     void subMultipleDynamicListError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(SUB_MULTIPLE_DYNAMIC_LIST_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -608,6 +614,7 @@ class BulkActionsControllerTest {
 
     @Test
     void createSubMultipleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(CREATE_SUB_MULTIPLE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -617,6 +624,7 @@ class BulkActionsControllerTest {
 
     @Test
     void filterDefaultedAllDynamicListError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(FILTER_DEFAULTED_ALL_DYNAMIC_LIST_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -626,6 +634,7 @@ class BulkActionsControllerTest {
 
     @Test
     void filterDefaultedNoneDynamicListError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(FILTER_DEFAULTED_NONE_DYNAMIC_LIST_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -635,6 +644,7 @@ class BulkActionsControllerTest {
 
     @Test
     void midUpdateSubMultipleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(MID_UPDATE_SUB_MULTIPLE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -644,6 +654,7 @@ class BulkActionsControllerTest {
 
     @Test
     void updateSubMultipleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(UPDATE_SUB_MULTIPLE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -653,6 +664,7 @@ class BulkActionsControllerTest {
 
     @Test
     void deleteSubMultipleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(DELETE_SUB_MULTIPLE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -662,6 +674,7 @@ class BulkActionsControllerTest {
 
     @Test
     void generateBulkScheduleError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(GENERATE_BULK_SCHEDULE_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -671,6 +684,7 @@ class BulkActionsControllerTest {
 
     @Test
     void preAcceptBulkError400() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mvc.perform(post(PRE_ACCEPT_BULK_URL)
                 .content("error")
                 .header(AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BundlesRespondentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/BundlesRespondentControllerTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.BundlesRespondentService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.FeatureToggleService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.SendNotificationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -29,16 +28,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest({BundlesRespondentController.class, JsonMapper.class})
-class BundlesRespondentControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class BundlesRespondentControllerTest extends BaseControllerTest {
+
     private static final String ABOUT_TO_START_URL = "/bundlesRespondent/aboutToStart";
     private static final String ABOUT_TO_SUBMIT_URL = "/bundlesRespondent/aboutToSubmit";
     private static final String MID_POPULATE_HEARINGS_URL = "/bundlesRespondent/midPopulateHearings";
     private static final String MID_VALIDATE_UPLOAD_URL = "/bundlesRespondent/midValidateUpload";
     private static final String SUBMITTED_URL = "/bundlesRespondent/submitted";
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private BundlesRespondentService bundlesRespondentService;
@@ -58,7 +54,9 @@ class BundlesRespondentControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         ccdRequest = CCDRequestBuilder.builder()
             .withCaseData(CaseDataBuilder.builder().build())
             .build();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerControllerTest.java
@@ -44,7 +44,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.NocRespondentRepresentati
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ScotlandFileLocationSelectionService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.SingleCaseMultipleMidEventValidationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.SingleReferenceService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -82,9 +81,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(CaseActionsForCaseWorkerController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class CaseActionsForCaseWorkerControllerTest {
+class CaseActionsForCaseWorkerControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String CREATION_CASE_URL = "/createCase";
     private static final String RETRIEVE_CASE_URL = "/retrieveCase";
     private static final String RETRIEVE_CASES_URL = "/retrieveCases";
@@ -149,9 +147,6 @@ class CaseActionsForCaseWorkerControllerTest {
 
     @MockBean
     private SingleReferenceService singleReferenceService;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private EventValidationService eventValidationService;
@@ -224,7 +219,9 @@ class CaseActionsForCaseWorkerControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         when(featureToggleService.isHmcEnabled()).thenReturn(true);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseFlagsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseFlagsControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseFlagsService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -27,16 +26,12 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({CaseFlagsController.class, JsonMapper.class})
-class CaseFlagsControllerTest {
+class CaseFlagsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_SUBMIT_URL = "/caseFlags/aboutToSubmit";
 
     @MockBean
     private CaseFlagsService caseFlagsService;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -45,7 +40,9 @@ class CaseFlagsControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseTransferControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseTransferControllerTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseManagementLocationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DefaultValuesReaderService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.FeatureToggleService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.casetransfer.CaseTransferDifferentCountryService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.casetransfer.CaseTransferSameCountryService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.casetransfer.CaseTransferToEcmService;
@@ -44,9 +43,7 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.service.TribunalOfficesSer
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({CaseTransferController.class, JsonMapper.class})
-class CaseTransferControllerTest {
-
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class CaseTransferControllerTest extends BaseControllerTest {
 
     private static final String INIT_TRANSFER_TO_SCOTLAND_URL = "/caseTransfer/initTransferToScotland";
     private static final String INIT_TRANSFER_TO_ENGLANDWALES_URL = "/caseTransfer/initTransferToEnglandWales";
@@ -56,9 +53,6 @@ class CaseTransferControllerTest {
     private static final String CASE_TRANSFER_DIFFERENT_COUNTRY_URL = "/caseTransfer/transferDifferentCountry";
     private static final String CASE_TRANSFER_TO_ECM = "/caseTransfer/transferToEcm";
     private static final String ASSIGN_CASE = "/caseTransfer/assignCase";
-
-    @MockBean
-    VerifyTokenService verifyTokenService;
 
     @MockBean
     CaseTransferSameCountryService caseTransferSameCountryService;
@@ -85,7 +79,9 @@ class CaseTransferControllerTest {
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp() {
+    @Override
+    void setUp() throws Exception {
+        super.setUp();
         when(featureToggleService.isHmcEnabled()).thenReturn(true);
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseTransferMultiplesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseTransferMultiplesControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.et.common.model.multiples.MultipleRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.casetransfer.MultipleTransferDifferentCountryService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.casetransfer.MultipleTransferSameCountryService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
@@ -33,17 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({CaseTransferMultiplesController.class, JsonMapper.class})
-class CaseTransferMultiplesControllerTest {
-
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class CaseTransferMultiplesControllerTest extends BaseControllerTest {
 
     private static final String INIT_TRANSFER_TO_SCOTLAND_URL = "/caseTransferMultiples/initTransferToScotland";
     private static final String INIT_TRANSFER_TO_ENGLANDWALES_URL = "/caseTransferMultiples/initTransferToEnglandWales";
     private static final String CASE_TRANSFER_SAME_COUNTRY_URL = "/caseTransferMultiples/transferSameCountry";
     private static final String CASE_TRANSFER_DIFFERENT_COUNTRY_URL = "/caseTransferMultiples/transferDifferentCountry";
-
-    @MockBean
-    VerifyTokenService verifyTokenService;
 
     @MockBean
     MultipleTransferSameCountryService multipleTransferSameCountryService;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/DigitalCaseFileControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/DigitalCaseFileControllerTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.client.BundleApiClient;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.UploadDocumentHelperTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DigitalCaseFileService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.ResourceLoader;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
@@ -36,16 +35,13 @@ import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.ET1_ATTACHM
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({DigitalCaseFileController.class, JsonMapper.class})
-class DigitalCaseFileControllerTest {
+class DigitalCaseFileControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String SELECT_BUNDLE_URL = "/dcf/selectDcf";
     private static final String ABOUT_TO_SUBMIT_URL = "/dcf/aboutToSubmit";
 
     @MockBean
     private BundleApiClient bundleApiClient;
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @MockBean
     private DigitalCaseFileService digitalCaseFileService;
     @Autowired
@@ -55,7 +51,9 @@ class DigitalCaseFileControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
                 .withEthosCaseReference("123456/2021")
                 .withClaimantIndType("First", "Last")

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/DocumentGenerationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/DocumentGenerationControllerTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DefaultValuesReaderService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentGenerationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -47,9 +46,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(DocumentGenerationController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class DocumentGenerationControllerTest {
+class DocumentGenerationControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String MID_ADDRESS_LABELS_URL = "/midAddressLabels";
     private static final String MID_SELECTED_ADDRESS_LABELS_URL = "/midSelectedAddressLabels";
     private static final String MID_VALIDATE_ADDRESS_LABELS_URL = "/midValidateAddressLabels";
@@ -70,9 +68,6 @@ class DocumentGenerationControllerTest {
     @MockBean
     private DefaultValuesReaderService defaultValuesReaderService;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
-
     private MockMvc mvc;
     private SubmitEvent submitEvent;
     private JsonNode requestContent;
@@ -84,7 +79,9 @@ class DocumentGenerationControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         submitEvent = new SubmitEvent();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ET1ServingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ET1ServingControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ServingService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 
@@ -32,16 +31,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({ET1ServingController.class, JsonMapper.class})
-class ET1ServingControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class ET1ServingControllerTest extends BaseControllerTest {
+
     private static final String SERVING_DOCUMENT_OTHER_TYPE_NAMES_URL = "/midServingDocumentOtherTypeNames";
     private static final String ABOUT_TO_SUBMIT_URL = "/et1Serving/aboutToSubmit";
     private static final String SUBMITTED_URL = "/et1Serving/submitted";
 
     private CCDRequest ccdRequest;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @MockBean
     private ServingService servingService;
     @Autowired
@@ -50,7 +47,9 @@ class ET1ServingControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
-    void setUp() {
+    @Override
+    void setUp() throws Exception {
+        super.setUp();
         CaseData caseData = new CaseData();
         caseData.setServingDocumentCollection(new ArrayList<>());
         caseData.setRespondentCollection(new ArrayList<>());

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et1VettingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et1VettingControllerTest.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.domain.referencedata.Jurisdiction
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentManagementService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.Et1VettingService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ReportDataService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 
@@ -41,18 +40,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({Et1VettingController.class, JsonMapper.class})
-class Et1VettingControllerTest {
+class Et1VettingControllerTest extends BaseControllerTest {
 
     private static final String INIT_CASE_VETTING_ENDPOINT = "/initialiseEt1Vetting";
     private static final String JURISDICTION_CODE_ENDPOINT = "/jurisdictionCodes";
     private static final String HEARING_VENUE_ENDPOINT = "/et1HearingVenue";
     private static final String ET1_PROCESSING_COMPLETE_URL = "/finishEt1Vetting";
     private static final String ET1_VETTING_ABOUT_TO_SUBMIT = "/et1VettingAboutToSubmit";
-    private static final String AUTH_TOKEN = "some-token";
     private CCDRequest ccdRequest;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @MockBean
     private Et1VettingService et1VettingService;
     @MockBean
@@ -66,7 +62,9 @@ class Et1VettingControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
-    void setUp() {
+    @Override
+    void setUp() throws Exception {
+        super.setUp();
         CaseData caseData = new CaseData();
         caseData.setManagingOffice("Manchester");
         addJurCodeToExistingCollection(caseData, JurisdictionCode.DOD.name());

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3NotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3NotificationControllerTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.Et3NotificationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ServingService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -36,14 +35,12 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({Et3NotificationController.class, JsonMapper.class})
-class Et3NotificationControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class Et3NotificationControllerTest extends BaseControllerTest {
+
     private static final String MID_UPLOAD_DOCUMENTS_URL = "/et3Notification/midUploadDocuments";
     private static final String SUBMITTED_URL = "/et3Notification/submitted";
     private CCDRequest ccdRequest;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @MockBean
     private ServingService servingService;
     @MockBean
@@ -54,7 +51,9 @@ class Et3NotificationControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
-    void setUp() {
+    @Override
+    void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("12345/6789")
             .withClaimantType("claimant@unrepresented.com")

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3ResponseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3ResponseControllerTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.Et3ResponseService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -34,8 +33,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Et3ResponseHelper.
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({Et3ResponseController.class, JsonMapper.class})
 @ContextConfiguration(classes = DocmosisApplication.class)
-class Et3ResponseControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class Et3ResponseControllerTest extends BaseControllerTest {
+
     private static final String ABOUT_TO_START_URL = "/et3Response/aboutToStart";
     private static final String PROCESSING_COMPLETE_URL = "/et3Response/processingComplete";
     private static final String MID_EMPLOYMENT_DATES_URL = "/et3Response/midEmploymentDates";
@@ -49,8 +48,6 @@ class Et3ResponseControllerTest {
     @Autowired
     private WebApplicationContext applicationContext;
     @MockBean
-    private VerifyTokenService verifyTokenService;
-    @MockBean
     private Et3ResponseService  et3ResponseService;
     private MockMvc mvc;
     private CCDRequest ccdRequest;
@@ -59,7 +56,9 @@ class Et3ResponseControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
 
         CaseDetails caseDetails = CaseDataBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3VettingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/Et3VettingControllerTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.DocumentManagementService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.Et3VettingService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.RespondentBuilder;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
@@ -41,8 +40,8 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({Et3VettingController.class, Et3VettingService.class, JsonMapper.class})
 @ContextConfiguration(classes = DocmosisApplication.class)
-class Et3VettingControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class Et3VettingControllerTest extends BaseControllerTest {
+
     private static final String POPULATE_ET3_DATES_URL = "/et3Vetting/midPopulateRespondentEt3Response";
     private static final String INIT_ET3_RESPONDENT_LIST_URL = "/et3Vetting/aboutToStart";
     private static final String CALCULATE_RESPONSE_TIME_URL = "/et3Vetting/midCalculateResponseInTime";
@@ -55,8 +54,6 @@ class Et3VettingControllerTest {
     @Autowired
     private WebApplicationContext applicationContext;
     @MockBean
-    private VerifyTokenService verifyTokenService;
-    @MockBean
     private DocumentManagementService documentManagementService;
     @MockBean
     private TornadoService tornadoService;
@@ -67,7 +64,9 @@ class Et3VettingControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
 
         CaseDetails caseDetails = CaseDataBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ExcelActionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ExcelActionsControllerTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.ClerkService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EventValidationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.FileLocationSelectionService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ScotlandFileLocationSelectionService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.FixMultipleCaseApiService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleAmendService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleCloseEventValidationService;
@@ -67,9 +66,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ExcelActionsController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class ExcelActionsControllerTest {
+class ExcelActionsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String CREATE_MULTIPLE_URL = "/createMultiple";
     private static final String AMEND_MULTIPLE_URL = "/amendMultiple";
     private static final String AMEND_MULTIPLE_API_URL = "/amendMultipleAPI";
@@ -116,9 +114,6 @@ class ExcelActionsControllerTest {
 
     @MockBean
     private MultipleUploadService multipleUploadService;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private MultipleDynamicListFlagsService multipleDynamicListFlagsService;
@@ -175,7 +170,9 @@ class ExcelActionsControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         DocumentInfo documentInfo = new DocumentInfo();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/GlobalSearchDataMigrationControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseManagementForCaseWorkerService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
 import java.io.File;
@@ -36,9 +35,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(GlobalSearchDataMigrationController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class GlobalSearchDataMigrationControllerTest {
+class GlobalSearchDataMigrationControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String GLOBAL_SEARCH_MIGRATION_SUBMITTED = "/global-search-migration/submitted";
     private static final String GLOBAL_SEARCH_MIGRATION_ABOUT_TO_SUBMIT = "/global-search-migration/about-to-submit";
     private static final String GLOBAL_SEARCH_ROLLBACK_SUBMITTED = "/global-search-rollback/submitted";
@@ -47,8 +45,6 @@ class GlobalSearchDataMigrationControllerTest {
 
     @MockBean
     private CaseManagementForCaseWorkerService caseManagementForCaseWorkerService;
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @Autowired
     private WebApplicationContext applicationContext;
@@ -56,7 +52,9 @@ class GlobalSearchDataMigrationControllerTest {
     private MockMvc mvc;
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         ObjectMapper objectMapper = new ObjectMapper();
         requestContent = objectMapper.readTree(new File(Objects.requireNonNull(getClass()

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/HearingUnavailabilityControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/HearingUnavailabilityControllerTest.java
@@ -5,12 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -24,13 +22,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest({HearingUnavailabilityController.class, JsonMapper.class})
-class HearingUnavailabilityControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class HearingUnavailabilityControllerTest extends BaseControllerTest {
+
     private static final String ABOUT_TO_SUBMIT_URL = "/hearingUnavailability/aboutToSubmit";
     private static final String SUBMITTED_URL = "/hearingUnavailability/submitted";
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @Autowired
     private JsonMapper jsonMapper;
@@ -41,7 +36,9 @@ class HearingUnavailabilityControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         ccdRequest = CCDRequestBuilder.builder()
                 .withCaseData(CaseDataBuilder.builder().build())
                 .build();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/InitialConsiderationControllerTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.FeatureToggleService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.InitialConsiderationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ReportDataService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -44,17 +43,14 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({InitialConsiderationController.class, JsonMapper.class})
 @ContextConfiguration(classes = DocmosisApplication.class)
-class InitialConsiderationControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class InitialConsiderationControllerTest extends BaseControllerTest {
+
     private static final String COMPLETE_INITIAL_CONSIDERATION_URL = "/completeInitialConsideration";
     private static final String START_INITIAL_CONSIDERATION_URL = "/startInitialConsideration";
     private static final String SUBMIT_INITIAL_CONSIDERATION_URL = "/submitInitialConsideration";
 
     @Autowired
     private WebApplicationContext applicationContext;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private InitialConsiderationService initialConsiderationService;
@@ -82,7 +78,9 @@ class InitialConsiderationControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         when(featureToggleService.isHmcEnabled()).thenReturn(true);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/IssueInitialConsiderationDirectionsWAControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/IssueInitialConsiderationDirectionsWAControllerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -15,7 +14,6 @@ import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -32,8 +30,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({IssueInitialConsiderationDirectionsWAController.class, JsonMapper.class})
 @ContextConfiguration(classes = DocmosisApplication.class)
-class IssueInitialConsiderationDirectionsWAControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class IssueInitialConsiderationDirectionsWAControllerTest extends BaseControllerTest {
 
     private static final String START_INITIAL_CONSIDERATION_DIRECTIONS_UR =
             "/startIssueInitialConsiderationDirectionsWA";
@@ -45,9 +42,6 @@ class IssueInitialConsiderationDirectionsWAControllerTest {
     @Autowired
     private WebApplicationContext applicationContext;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
-
     private MockMvc mvc;
 
     private CCDRequest ccdRequest;
@@ -56,7 +50,9 @@ class IssueInitialConsiderationDirectionsWAControllerTest {
     private JsonMapper jsonMapper;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
 
         CaseDetails caseDetails = CaseDataBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/LegalRepDocumentsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/LegalRepDocumentsControllerTest.java
@@ -5,13 +5,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -26,13 +24,9 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({LegalRepDocumentsController.class, JsonMapper.class})
-class LegalRepDocumentsControllerTest {
+class LegalRepDocumentsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/legalrepDocuments/aboutToStart";
-    
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -41,7 +35,9 @@ class LegalRepDocumentsControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ListHearingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ListHearingControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.hearings.allocatehearing.ScotlandVenueSelectionService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.hearings.allocatehearing.VenueSelectionService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
@@ -29,10 +28,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.SCOTLAND_CASE_TYPE_
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({ListHearingController.class, JsonMapper.class})
-class ListHearingControllerTest {
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+class ListHearingControllerTest extends BaseControllerTest {
 
     @MockBean
     private VenueSelectionService venueSelectionService;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ListingGenerationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ListingGenerationControllerTest.java
@@ -36,7 +36,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.GenerateReportService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ListingService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.PrintHearingListService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ReportDataService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -72,7 +71,7 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ListingGenerationController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class ListingGenerationControllerTest {
+class ListingGenerationControllerTest extends BaseControllerTest {
 
     private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String LISTING_CASE_CREATION_URL = "/listingCaseCreation";
@@ -100,9 +99,6 @@ class ListingGenerationControllerTest {
 
     @MockBean
     private DefaultValuesReaderService defaultValuesReaderService;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private PrintHearingListService printHearingListService;
@@ -214,7 +210,9 @@ class ListingGenerationControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         listingDetails = new ListingDetails();
@@ -783,7 +781,6 @@ class ListingGenerationControllerTest {
     @Test
     void initGenerateReportForbidden() throws Exception {
         mvc.perform(post(INIT_GENERATE_REPORT_URL)
-                        .header(AUTHORIZATION, AUTH_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestContent.toString()))
                 .andExpect(status().isForbidden());

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/MultipleDocGenerationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/MultipleDocGenerationControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.et.common.model.ccd.DocumentInfo;
 import uk.gov.hmcts.et.common.model.multiples.MultipleDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleDocGenerationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleLetterService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.excel.MultipleScheduleService;
@@ -44,9 +43,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(MultipleDocGenerationController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class MultipleDocGenerationControllerTest {
+class MultipleDocGenerationControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String PRINT_SCHEDULE_URL = "/printSchedule";
     private static final String PRINT_LETTER_URL = "/printLetter";
     private static final String PRINT_DOCUMENT_CONFIRMATION_URL = "/printDocumentConfirmation";
@@ -64,9 +62,6 @@ class MultipleDocGenerationControllerTest {
     private MultipleScheduleService multipleScheduleService;
 
     @MockBean
-    private VerifyTokenService verifyTokenService;
-
-    @MockBean
     private MultipleDocGenerationService multipleDocGenerationService;
 
     private MockMvc mvc;
@@ -80,7 +75,9 @@ class MultipleDocGenerationControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         documentInfo = new DocumentInfo();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/PersistentQueueActionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/PersistentQueueActionsControllerTest.java
@@ -30,7 +30,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.BulkCreationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.BulkSearchService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.BulkUpdateService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -56,9 +55,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(PersistentQueueActionsController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class PersistentQueueActionsControllerTest {
+class PersistentQueueActionsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String AFTER_SUBMITTED_PQ_BULK_URL = "/afterSubmittedBulkPQ";
     private static final String PRE_ACCEPT_PQ_BULK_URL = "/preAcceptBulkPQ";
     private static final String UPDATE_BULK_CASE_PQ_URL = "/updateBulkCasePQ";
@@ -75,9 +73,6 @@ class PersistentQueueActionsControllerTest {
     @MockBean
     private BulkSearchService bulkSearchService;
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
-
     private MockMvc mvc;
     private JsonNode requestContent;
     private BulkCasesPayload bulkCasesPayload;
@@ -90,7 +85,9 @@ class PersistentQueueActionsControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         List<SubmitEvent> submitEvents;

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/PseViewNotificationsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/PseViewNotificationsControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.PseRespondentViewService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -27,13 +26,10 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({PseViewNotificationsController.class, JsonMapper.class})
-class PseViewNotificationsControllerTest {
+class PseViewNotificationsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/pseViewNotifications/aboutToStart";
-    
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+
     @MockBean
     private PseRespondentViewService pseRespondentViewService;
     @Autowired
@@ -43,7 +39,9 @@ class PseViewNotificationsControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ReferenceDataControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/ReferenceDataControllerTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ethos.replacement.docmosis.DocmosisApplication;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.ReferenceService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 
@@ -40,9 +39,8 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.utils.InternalException.ER
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ReferenceDataController.class)
 @ContextConfiguration(classes = DocmosisApplication.class)
-class ReferenceDataControllerTest {
+class ReferenceDataControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String HEARING_VENUE_REFERENCE_DATA = "/hearingVenueReferenceData";
     private static final String DATE_LISTED_REFERENCE_DATA = "/dateListedReferenceData";
 
@@ -51,9 +49,6 @@ class ReferenceDataControllerTest {
 
     @MockBean
     private ReferenceService referenceService;
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     private MockMvc mvc;
     private JsonNode requestContent;
@@ -66,7 +61,9 @@ class ReferenceDataControllerTest {
     }
 
     @BeforeEach
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
         doRequestSetUp();
         submitEvent = new SubmitEvent();

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondNotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondNotificationControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.RespondNotificationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -30,9 +29,8 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({RespondNotificationController.class, JsonMapper.class})
-class RespondNotificationControllerTest {
+class RespondNotificationControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/respondNotification/aboutToStart";
     private static final String ABOUT_TO_SUBMIT_URL = "/respondNotification/aboutToSubmit";
     private static final String MID_GET_NOTIFICATION_URL = "/respondNotification/midGetNotification";
@@ -41,8 +39,6 @@ class RespondNotificationControllerTest {
 
     @MockBean
     private RespondNotificationService respondNotificationService;
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @Autowired
     private MockMvc mockMvc;
     @Autowired
@@ -50,7 +46,9 @@ class RespondNotificationControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
                 .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondentTellSomethingElseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/RespondentTellSomethingElseControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
@@ -21,7 +20,6 @@ import uk.gov.hmcts.et.common.model.ccd.types.RespondentSumType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.Helper;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.RespondentTellSomethingElseService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -49,17 +47,13 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.NO;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({RespondentTellSomethingElseController.class, JsonMapper.class})
-class RespondentTellSomethingElseControllerTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
+class RespondentTellSomethingElseControllerTest extends BaseControllerTest {
     private static final String VALIDATE_GIVE_DETAILS = "/respondentTSE/validateGiveDetails";
     private static final String ABOUT_TO_SUBMIT_URL = "/respondentTSE/aboutToSubmit";
     private static final String DISPLAY_TABLE_URL = "/respondentTSE/displayTable";
     private static final String COMPLETE_APPLICATION_URL = "/respondentTSE/completeApplication";
     private static final String ABOUT_TO_START_URL = "/respondentTSE/aboutToStart";
     private static final String SHOW_ERROR_URL = "/respondentTSE/showError";
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private RespondentTellSomethingElseService resTseService;
@@ -74,7 +68,9 @@ class RespondentTellSomethingElseControllerTest {
     private MockedStatic mockHelper;
 
     @BeforeEach
-    void setUp() {
+    @Override
+    void setUp() throws Exception {
+        super.setUp();
         CaseData caseData = CaseDataBuilder.builder()
             .withEthosCaseReference("test")
             .withClaimant("claimant")
@@ -127,7 +123,7 @@ class RespondentTellSomethingElseControllerTest {
         mockMvc.perform(post(ABOUT_TO_START_URL)
                         .content("garbage content")
                         .header("Authorization", AUTH_TOKEN)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/SendNotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/SendNotificationControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.SendNotificationService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -27,15 +26,12 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({SendNotificationController.class, JsonMapper.class})
-class SendNotificationControllerTest {
+class SendNotificationControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_SUBMIT_URL = "/sendNotification/aboutToSubmit";
     private static final String ABOUT_TO_START_URL = "/sendNotification/aboutToStart";
     private static final String SUBMITTED_URL = "/sendNotification/submitted";
 
-    @MockBean
-    private VerifyTokenService verifyTokenService;
     @MockBean
     private SendNotificationService sendNotificationService;
 
@@ -46,7 +42,9 @@ class SendNotificationControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder().buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);
 
         caseDetails.getCaseData().setEthosCaseReference("1234");

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdmReplyControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdmReplyControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseAdmReplyService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -29,10 +28,7 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.ENGLANDWALES_CASE_T
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({TseAdmReplyController.class, JsonMapper.class})
-class TseAdmReplyControllerTest {
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+class TseAdmReplyControllerTest extends BaseControllerTest {
 
     @MockBean
     private TseAdmReplyService tseAdmReplyService;
@@ -45,14 +41,15 @@ class TseAdmReplyControllerTest {
 
     private CCDRequest ccdRequest;
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String MID_DETAILS_TABLE = "/tseAdmReply/midDetailsTable";
     private static final String MID_VALIDATE_INPUT = "/tseAdmReply/midValidateInput";
     private static final String ABOUT_TO_SUBMIT_URL = "/tseAdmReply/aboutToSubmit";
     private static final String SUBMITTED_URL = "/tseAdmReply/submitted";
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("1234")
             .buildAsCaseDetails(ENGLANDWALES_CASE_TYPE_ID);

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdminControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseAdminControllerTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseFlagsService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.FeatureToggleService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseAdmCloseService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseAdminService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -41,18 +40,14 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.TSE_APP_CHANGE_PERS
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({TseAdminController.class, JsonMapper.class})
-class TseAdminControllerTest {
+class TseAdminControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/tseAdmin/aboutToStart";
     private static final String MID_DETAILS_TABLE = "/tseAdmin/midDetailsTable";
     private static final String ABOUT_TO_SUBMIT_URL = "/tseAdmin/aboutToSubmit";
     private static final String SUBMITTED_URL = "/tseAdmin/submitted";
     private static final String ABOUT_TO_SUBMIT_CLOSE_APP_URL = "/tseAdmin/aboutToSubmitCloseApplication";
     private static final String SUBMITTED_CLOSE_APP_URL = "/tseAdmin/submittedCloseApplication";
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
 
     @MockBean
     private TseAdminService tseAdminService;
@@ -72,7 +67,9 @@ class TseAdminControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         when(featureToggleService.isHmcEnabled()).thenReturn(true);
         CaseDetails caseDetails = CaseDataBuilder.builder()
             .withEthosCaseReference("1234")

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseRespondentReplyControllerTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.Helper;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseRespondentReplyService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -38,9 +37,8 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({TseRespondentReplyController.class, JsonMapper.class})
-class TseRespondentReplyControllerTest {
+class TseRespondentReplyControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/tseResponse/aboutToStart";
     private static final String MID_POPULATE_REPLY_URL = "/tseResponse/midPopulateReply";
     private static final String ABOUT_TO_SUBMIT_URL = "/tseResponse/aboutToSubmit";
@@ -53,15 +51,15 @@ class TseRespondentReplyControllerTest {
     private JsonMapper jsonMapper;
 
     @MockBean
-    private VerifyTokenService verifyTokenService;
-    @MockBean
     private TseRespondentReplyService tseRespondentReplyService;
 
     private MockedStatic<Helper> mockHelper;
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseData caseData = CaseDataBuilder.builder()
             .withEthosCaseReference("9876")
             .withClaimantType("person@email.com")

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseViewApplicationsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/TseViewApplicationsControllerTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.ethos.replacement.docmosis.helpers.HelperTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TornadoService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.TseService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.UserIdamService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -32,9 +31,8 @@ import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({TseViewApplicationsController.class, JsonMapper.class})
-class TseViewApplicationsControllerTest {
+class TseViewApplicationsControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String MID_POPULATE_CHOOSE_APPLICATION_URL =
             "/viewRespondentTSEApplications/midPopulateChooseApplication";
 
@@ -47,8 +45,6 @@ class TseViewApplicationsControllerTest {
     @Autowired
     private MockMvc mockMvc;
     @MockBean
-    private VerifyTokenService verifyTokenService;
-    @MockBean
     private UserIdamService userIdamService;
     @Autowired
     private JsonMapper jsonMapper;
@@ -60,7 +56,9 @@ class TseViewApplicationsControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         CaseData caseData = CaseDataBuilder.builder()
             .withEthosCaseReference("9876")
             .withClaimantType("testing@test.com")

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/UploadDocumentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/UploadDocumentControllerTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.et.common.model.ccd.types.ClaimantType;
 import uk.gov.hmcts.ethos.replacement.docmosis.helpers.UploadDocumentHelperTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseManagementForCaseWorkerService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.EmailService;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
 import uk.gov.hmcts.ethos.utils.CCDRequestBuilder;
 import uk.gov.hmcts.ethos.utils.CaseDataBuilder;
@@ -34,14 +33,11 @@ import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.REJECTION_O
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({UploadDocumentController.class, JsonMapper.class})
-class UploadDocumentControllerTest {
+class UploadDocumentControllerTest extends BaseControllerTest {
 
-    private static final String AUTH_TOKEN = "Bearer eyJhbGJbpjciOiJIUzI1NiJ9";
     private static final String ABOUT_TO_START_URL = "/uploadDocument/aboutToStart";
     private static final String ABOUT_TO_SUBMIT_URL = "/uploadDocument/aboutToSubmit";
-    
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+
     @MockBean
     private EmailService emailService;
     @MockBean
@@ -53,7 +49,9 @@ class UploadDocumentControllerTest {
     private CCDRequest ccdRequest;
 
     @BeforeEach
+    @Override
     void setUp() throws Exception {
+        super.setUp();
         when(emailService.getCitizenCaseLink(any())).thenReturn("");
 
         CaseDetails caseDetails = CaseDataBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/filelocation/FileLocationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/filelocation/FileLocationControllerTest.java
@@ -8,9 +8,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.ethos.replacement.docmosis.controllers.BaseControllerTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.CCDRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.filelocation.FileLocationService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.filelocation.SaveFileLocationException;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.AdminDataBuilder;
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -40,10 +39,7 @@ import static uk.gov.hmcts.ethos.replacement.docmosis.service.admin.filelocation
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({FileLocationController.class, JsonMapper.class})
-class FileLocationControllerTest {
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+class FileLocationControllerTest extends BaseControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -142,11 +138,10 @@ class FileLocationControllerTest {
     void testInitAdminDataBadRequest() throws Exception {
         mockMvc.perform(post("/admin/filelocation/initAdminData")
                         .contentType(APPLICATION_JSON)
-                        .header("Authorization", "user-token")
+                        .header("Authorization", AUTH_TOKEN)
                         .content("bad-request"))
                 .andExpect(status().isBadRequest());
 
-        verify(verifyTokenService, never()).verifyTokenSignature(anyString());
         verify(fileLocationService, never()).initAdminData(any(AdminData.class));
     }
   

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/staff/StaffImportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/staff/StaffImportControllerTest.java
@@ -8,9 +8,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.ethos.replacement.docmosis.controllers.BaseControllerTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.CCDRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.staff.StaffImportService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.AdminDataBuilder;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
@@ -31,10 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({StaffImportController.class, JsonMapper.class})
-class StaffImportControllerTest {
-
-    @MockBean
-    private VerifyTokenService verifyTokenService;
+class StaffImportControllerTest extends BaseControllerTest {
 
     @MockBean
     private StaffImportService staffImportService;
@@ -90,7 +87,7 @@ class StaffImportControllerTest {
     void testImportBadRequest() throws Exception {
         mockMvc.perform(post("/admin/staff/import")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "some-token")
+                        .header("Authorization", AUTH_TOKEN)
                         .content("error"))
                 .andExpect(status().isBadRequest());
         verify(staffImportService, never()).importStaff(isA(AdminData.class), isA(String.class));

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/venues/VenueImportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/admin/venues/VenueImportControllerTest.java
@@ -9,9 +9,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
+import uk.gov.hmcts.ethos.replacement.docmosis.controllers.BaseControllerTest;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.AdminData;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.admin.CCDRequest;
-import uk.gov.hmcts.ethos.replacement.docmosis.service.VerifyTokenService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.admin.venues.VenueImportService;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.AdminDataBuilder;
 import uk.gov.hmcts.ethos.replacement.docmosis.utils.JsonMapper;
@@ -30,10 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest({VenueImportController.class, JsonMapper.class})
-class VenueImportControllerTest {
-    @MockBean
-    private VerifyTokenService verifyTokenService;
-
+class VenueImportControllerTest extends BaseControllerTest {
     @MockBean
     private VenueImportService venueImportService;
 
@@ -87,11 +84,10 @@ class VenueImportControllerTest {
     void testInitImportBadRequest() throws Exception {
         mockMvc.perform(post("/admin/venue/initImport")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "user-token")
+                        .header("Authorization", AUTH_TOKEN)
                         .content("bad-request"))
                 .andExpect(status().isBadRequest());
 
-        verify(verifyTokenService, never()).verifyTokenSignature(anyString());
         verify(venueImportService, never()).initImport(any(AdminData.class));
     }
 
@@ -140,11 +136,10 @@ class VenueImportControllerTest {
     void testImportBadRequest() throws Exception {
         mockMvc.perform(post("/admin/venue/import")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "user-token")
+                        .header("Authorization", AUTH_TOKEN)
                         .content("bad-request"))
                 .andExpect(status().isBadRequest());
 
-        verify(verifyTokenService, never()).verifyTokenSignature(anyString());
         verify(venueImportService, never()).importVenues(any(AdminData.class), anyString());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-0000

### Change description ###

Added request interceptor for token verify service - like what we have for et-sya-api

This doesn't remove the explicit checks from controllers - trying to keep PRs small

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
