### PR TITLE
RET-5037: Showing respond button for ECC only notifications that require it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ ext["rest-assured.version"] = '5.1.0'
 
 dependencyManagement {
     dependencies {
-        dependencySet(group: 'com.google.guava', version: '33.1.0-jre') {
+        dependencySet(group: 'com.google.guava', version: '33.2.0-jre') {
             entry 'guava'
         }
         dependencySet(group: 'io.netty', version: '4.1.109.Final') {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
@@ -143,8 +143,8 @@ public class SendNotificationService {
     }
 
     private static void setStatusForCitizenHub(CaseData caseData, SendNotificationType sendNotificationType) {
-        if (caseData.getSendNotificationResponseTribunal().equals(SEND_NOTIFICATION_RESPONSE_REQUIRED)
-                && !caseData.getSendNotificationSelectParties().equals(RESPONDENT_ONLY)) {
+        if (SEND_NOTIFICATION_RESPONSE_REQUIRED.equals(caseData.getSendNotificationResponseTribunal())
+                && !RESPONDENT_ONLY.equals(caseData.getSendNotificationSelectParties())) {
             sendNotificationType.setNotificationState(NOT_STARTED_YET);
         } else {
             sendNotificationType.setNotificationState(NOT_VIEWED_YET);

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/SendNotificationService.java
@@ -143,8 +143,7 @@ public class SendNotificationService {
     }
 
     private static void setStatusForCitizenHub(CaseData caseData, SendNotificationType sendNotificationType) {
-        if (sendNotificationType.getSendNotificationSubject().contains(CASE_MANAGEMENT_ORDERS_REQUESTS)
-                && caseData.getSendNotificationResponseTribunal().equals(SEND_NOTIFICATION_RESPONSE_REQUIRED)
+        if (caseData.getSendNotificationResponseTribunal().equals(SEND_NOTIFICATION_RESPONSE_REQUIRED)
                 && !caseData.getSendNotificationSelectParties().equals(RESPONDENT_ONLY)) {
             sendNotificationType.setNotificationState(NOT_STARTED_YET);
         } else {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-5037

### Change description ###

Showing respond button for ECC only notifications that require it

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
