### PR TITLE
ET3Vetting address concatenation causing symbols to appear

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3VettingHelper.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3VettingHelper.java
@@ -79,7 +79,7 @@ public final class Et3VettingHelper {
     private static final String RESPONDENT_DETAILS = "<h2>Respondent</h2>"
         + "<pre>Name &#09&#09&#09&#09&#09&#09&nbsp; %s"
         + "<br><br>Contact address &#09&#09 %s</pre><hr>";
-    private static final String BR_WITH_TAB = "<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09";
+    private static final String BR_WITH_TAB = "<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 ";
     private static final int ET3_RESPONSE_WINDOW = 28;
     private static final String NONE = "None";
     private static final String NONE_GIVEN = "None Given";

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3VettingHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/helpers/Et3VettingHelperTest.java
@@ -351,8 +351,8 @@ class Et3VettingHelperTest {
 
         Et3VettingHelper.setRespondentNameAndAddress(caseData);
         String expected = "<h2>Respondent</h2><pre>Name &#09&#09&#09&#09&#09&#09&nbsp; John<br><br>Contact "
-            + "address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09Erith<br>&#09&#09&#09&#09&#09"
-            + "&#09&#09&#09&#09<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09DA8 2DE</pre><hr>";
+            + "address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Erith<br>&#09&#09&#09&#09&#09"
+            + "&#09&#09&#09&#09 <br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 DA8 2DE</pre><hr>";
 
         assertThat(caseData.getEt3NameAddressRespondent(), is(expected));
     }
@@ -395,8 +395,8 @@ class Et3VettingHelperTest {
 
         Et3VettingHelper.setRespondentNameAndAddress(caseData);
         String expected = "<h2>Respondent</h2><pre>Name &#09&#09&#09&#09&#09&#09&nbsp; None Given<br><br>"
-            + "Contact address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09Erith<br>&#09&#09&#09"
-            + "&#09&#09&#09&#09&#09&#09<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09DA8 2DE</pre><hr>";
+            + "Contact address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Erith<br>&#09&#09&#09"
+            + "&#09&#09&#09&#09&#09&#09 <br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 DA8 2DE</pre><hr>";
 
         assertThat(caseData.getEt3NameAddressRespondent(), is(expected));
     }
@@ -418,9 +418,9 @@ class Et3VettingHelperTest {
 
         Et3VettingHelper.setRespondentNameAndAddress(caseData);
         String expected = "<h2>Respondent</h2><pre>Name &#09&#09&#09&#09&#09&#09&nbsp; John<br><br>Contact "
-            + "address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09Erith<br>&#09&#09&#09&#09&#09"
-            + "&#09&#09&#09&#09Erith<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09Erith<br>&#09&#09&#09&#09&#09&#09&#09&#09"
-            + "&#09DA8 2DE</pre><hr>";
+            + "address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Erith<br>&#09&#09&#09&#09&#09"
+            + "&#09&#09&#09&#09 Erith<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Erith<br>&#09&#09&#09&#09&#09&#09&#09&#09"
+            + "&#09 DA8 2DE</pre><hr>";
 
         assertThat(caseData.getEt3NameAddressRespondent(), is(expected));
     }
@@ -443,8 +443,8 @@ class Et3VettingHelperTest {
         Et3VettingHelper.setRespondentNameAndAddress(caseData);
 
         String expected = "<h2>Respondent</h2><pre>Name &#09&#09&#09&#09&#09&#09&nbsp; John<br><br>Contact"
-            + " address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09Erith<br>&#09&#09&#09&#09&#09"
-            + "&#09&#09&#09&#09<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09DA8 2DE</pre><hr>";
+            + " address &#09&#09 32 Bridge Road<br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 Erith<br>&#09&#09&#09&#09&#09"
+            + "&#09&#09&#09&#09 <br>&#09&#09&#09&#09&#09&#09&#09&#09&#09 DA8 2DE</pre><hr>";
 
         assertThat(caseData.getEt3NameAddressRespondent(), is(expected));
     }


### PR DESCRIPTION
### Change description
Spacing issue causing symbols to be shown when address lines start with a number

* updated linebreak text to have a gap before concatenation
* updated unit tests

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
