### PR TITLE
CVE Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,7 +399,8 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.13'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.13'
     implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.2.13'
-
+    // CVE-2025-48734
+    implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.11.0'
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.7.0'
 
     runtimeOnly group: 'com.squareup.okio', name: 'okio-jvm', version: '3.10.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -146,83 +146,14 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene\-suggest@.*$</packageUrl>
         <cve>CVE-2024-45772</cve>
     </suppress>
+    <!-- Below to be removed when migrated from Springboot 2.7.18 to 3.x https://tools.hmcts.net/jira/browse/RET-5770 -->
     <suppress>
-        <notes><![CDATA[
-   file name: spring-aop-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
         <cve>CVE-2024-38820</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-   file name: spring-aspects-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aspects@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
+        <cve>CVE-2024-22259</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-beans-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-context-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-core-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-expression-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-jcl-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jcl@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-jdbc-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-orm-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-orm@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-tx-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-webmvc-5.3.31.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
-        <cve>CVE-2024-38820</cve>
-    </suppress>
+    <!-- Above to be removed when migrated from Springboot 2.7.18 to 3.x https://tools.hmcts.net/jira/browse/RET-5770-->
     <suppress>
         <notes><![CDATA[
         Suppressing CVE-2023-51775 for jose4j-0.9.3.jar


### PR DESCRIPTION
- Suppress Spring CVEs as they will be fixed as part of the Spring 3 migration
- Add commons-beanutils library as bumping Checkstyle (see https://github.com/hmcts/et-sya-api/pull/1302) does not resolve the issue due to other libraries also referencing the library with the vulnerability