### PR TITLE
Update HearingDetailService to handle null values for hearing details

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -54,6 +54,13 @@
         <packageUrl regex="true">^pkg:maven/com\.microsoft\.rest/client-runtime.*$</packageUrl>
         <cve>CVE-2024-43591</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: adal4j-1.6.7.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/adal4j@.*$</packageUrl>
+        <cpe>cpe:/a:microsoft:azure_active_directory</cpe>
+    </suppress>
     <!-- Above to be removed when migrated to DB instead of SB queue -->
     <suppress>
         <notes><![CDATA[

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.YES;
 import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.FlagsImageHelper.buildFlagsImageFileName;
@@ -52,10 +51,6 @@ public class HearingDetailsService {
         if (isNotEmpty(hearingDetailTypeItemList)) {
             caseData.setHearingDetailsCollection(hearingDetailTypeItemList);
         }
-    }
-
-    private String nonNull(String value) {
-        return isNullOrEmpty(value) ? " " : value;
     }
 
     public void updateCase(CaseDetails caseDetails) {

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailsService.java
@@ -135,22 +135,22 @@ public class HearingDetailsService {
     private HearingDetailTypeItem getHearingDetailTypeItem(DateListedType dateListedType) {
         HearingDetailType hearingDetailType = new HearingDetailType();
         hearingDetailType.setHearingDetailsDate(dateListedType.getListedDate());
-        hearingDetailType.setHearingDetailsStatus(nonNull(dateListedType.getHearingStatus()));
-        hearingDetailType.setHearingDetailsPostponedBy(nonNull(dateListedType.getPostponedBy()));
-        hearingDetailType.setHearingDetailsCaseDisposed(nonNull(dateListedType.getHearingCaseDisposed()));
-        hearingDetailType.setHearingDetailsPartHeard(nonNull(dateListedType.getHearingPartHeard()));
-        hearingDetailType.setHearingDetailsReservedJudgment(nonNull(dateListedType.getHearingReservedJudgement()));
-        hearingDetailType.setHearingDetailsAttendeeClaimant(nonNull(dateListedType.getAttendeeClaimant()));
-        hearingDetailType.setHearingDetailsAttendeeNonAttendees(nonNull(dateListedType.getAttendeeNonAttendees()));
-        hearingDetailType.setHearingDetailsAttendeeRespNoRep(nonNull(dateListedType.getAttendeeRespNoRep()));
-        hearingDetailType.setHearingDetailsAttendeeRespAndRep(nonNull(dateListedType.getAttendeeRespAndRep()));
-        hearingDetailType.setHearingDetailsAttendeeRepOnly(nonNull(dateListedType.getAttendeeRepOnly()));
-        hearingDetailType.setHearingDetailsTimingStart(nonNull(dateListedType.getHearingTimingStart()));
+        hearingDetailType.setHearingDetailsStatus(dateListedType.getHearingStatus());
+        hearingDetailType.setHearingDetailsPostponedBy(dateListedType.getPostponedBy());
+        hearingDetailType.setHearingDetailsCaseDisposed(dateListedType.getHearingCaseDisposed());
+        hearingDetailType.setHearingDetailsPartHeard(dateListedType.getHearingPartHeard());
+        hearingDetailType.setHearingDetailsReservedJudgment(dateListedType.getHearingReservedJudgement());
+        hearingDetailType.setHearingDetailsAttendeeClaimant(dateListedType.getAttendeeClaimant());
+        hearingDetailType.setHearingDetailsAttendeeNonAttendees(dateListedType.getAttendeeNonAttendees());
+        hearingDetailType.setHearingDetailsAttendeeRespNoRep(dateListedType.getAttendeeRespNoRep());
+        hearingDetailType.setHearingDetailsAttendeeRespAndRep(dateListedType.getAttendeeRespAndRep());
+        hearingDetailType.setHearingDetailsAttendeeRepOnly(dateListedType.getAttendeeRepOnly());
+        hearingDetailType.setHearingDetailsTimingStart(dateListedType.getHearingTimingStart());
         hearingDetailType.setHearingDetailsTimingBreak(dateListedType.getHearingTimingBreak());
         hearingDetailType.setHearingDetailsTimingResume(dateListedType.getHearingTimingResume());
-        hearingDetailType.setHearingDetailsTimingFinish(nonNull(dateListedType.getHearingTimingFinish()));
-        hearingDetailType.setHearingDetailsTimingDuration(nonNull(dateListedType.getHearingTimingDuration()));
-        hearingDetailType.setHearingDetailsHearingNotes2(nonNull(dateListedType.getHearingNotes2()));
+        hearingDetailType.setHearingDetailsTimingFinish(dateListedType.getHearingTimingFinish());
+        hearingDetailType.setHearingDetailsTimingDuration(dateListedType.getHearingTimingDuration());
+        hearingDetailType.setHearingDetailsHearingNotes2(dateListedType.getHearingNotes2());
 
         HearingDetailTypeItem hearingDetailTypeItem = new HearingDetailTypeItem();
         hearingDetailTypeItem.setId(UUID.randomUUID().toString());

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/hearings/hearingdetails/HearingDetailServiceTest.java
@@ -130,20 +130,20 @@ class HearingDetailServiceTest {
         CaseData caseData = createCaseData();
         hearingDetailsService.handleListingSelected(caseData);
         HearingDetailType hearingDetailType = caseData.getHearingDetailsCollection().get(0).getValue();
-        assertEquals(" ", hearingDetailType.getHearingDetailsStatus());
-        assertEquals(" ", hearingDetailType.getHearingDetailsPostponedBy());
-        assertEquals(" ", hearingDetailType.getHearingDetailsCaseDisposed());
-        assertEquals(" ", hearingDetailType.getHearingDetailsPartHeard());
-        assertEquals(" ", hearingDetailType.getHearingDetailsReservedJudgment());
-        assertEquals(" ", hearingDetailType.getHearingDetailsAttendeeClaimant());
-        assertEquals(" ", hearingDetailType.getHearingDetailsAttendeeNonAttendees());
-        assertEquals(" ", hearingDetailType.getHearingDetailsAttendeeRespNoRep());
-        assertEquals(" ", hearingDetailType.getHearingDetailsAttendeeRespAndRep());
-        assertEquals(" ", hearingDetailType.getHearingDetailsAttendeeRepOnly());
-        assertEquals(" ", hearingDetailType.getHearingDetailsTimingStart());
-        assertEquals(" ", hearingDetailType.getHearingDetailsTimingFinish());
-        assertEquals(" ", hearingDetailType.getHearingDetailsTimingDuration());
-        assertEquals(" ", hearingDetailType.getHearingDetailsHearingNotes2());
+        assertNull(hearingDetailType.getHearingDetailsStatus());
+        assertNull(hearingDetailType.getHearingDetailsPostponedBy());
+        assertNull(hearingDetailType.getHearingDetailsCaseDisposed());
+        assertNull(hearingDetailType.getHearingDetailsPartHeard());
+        assertNull(hearingDetailType.getHearingDetailsReservedJudgment());
+        assertNull(hearingDetailType.getHearingDetailsAttendeeClaimant());
+        assertNull(hearingDetailType.getHearingDetailsAttendeeNonAttendees());
+        assertNull(hearingDetailType.getHearingDetailsAttendeeRespNoRep());
+        assertNull(hearingDetailType.getHearingDetailsAttendeeRespAndRep());
+        assertNull(hearingDetailType.getHearingDetailsAttendeeRepOnly());
+        assertNull(hearingDetailType.getHearingDetailsTimingStart());
+        assertNull(hearingDetailType.getHearingDetailsTimingFinish());
+        assertNull(hearingDetailType.getHearingDetailsTimingDuration());
+        assertNull(hearingDetailType.getHearingDetailsHearingNotes2());
     }
 
     @Test


### PR DESCRIPTION
Remove code that is adding blank space to fields; not sure why it was done in the first place tbh.
Number fields are being pre-populated with spaces which then cause errors. Users are having to manually clear out the fields when they shouldn't have to
![Screenshot 2025-07-10 at 09 12 35](https://github.com/user-attachments/assets/0c21a1c7-62ee-4bc2-8b9f-d067ea72f9bf)
