### PR TITLE
VirtualThreads on Submission

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/AsyncConfig.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/config/AsyncConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.ethos.replacement.docmosis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "etAsyncExecutor", destroyMethod = "shutdown")
+    public ExecutorService etAsyncExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/controllers/CaseActionsForCaseWorkerController.java
@@ -282,9 +282,7 @@ public class CaseActionsForCaseWorkerController {
 
             if (featureToggleService.citizenEt1Generation() && SUBMIT_CASE_DRAFT.equals(ccdRequest.getEventId())) {
                 caseDetails.setCaseData(caseData);
-                et1SubmissionService.createAndUploadEt1Docs(caseDetails, userToken);
-                et1SubmissionService.sendEt1ConfirmationClaimant(caseDetails, userToken);
-                et1SubmissionService.vexationCheck(caseDetails, userToken);
+                et1SubmissionService.submitEt1(caseDetails, userToken);
             }
         }
 


### PR DESCRIPTION
### Jira link

No ticket just yet

### Change description

Added a VirutalThread runner into callbacks and implemented a parallel runner for submission to speed up submission processes

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
