### PR TITLE
CVE Master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,6 @@ dependencies {
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.10.2'
 
     runtimeOnly group: 'com.squareup.okio', name: 'okio-jvm', version: '3.16.0'
-    runtimeOnly group: 'org.eclipse.angus', name: 'angus-activation', version: '2.0.3'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,4 +41,8 @@
     <suppress>
         <cve>CVE-2024-38820</cve>
     </suppress>
+    <!-- Suppressing due to dependency on other services as we use CFTLib and the latest version 2.0.3 doesn't fix the issue-->
+    <suppress until="2025-12-10Z">
+        <cve>CVE-2025-7962</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- Update Tomcat
- Suppress Angus Activation as latest version 2.0.3 still has CVEs and is also being from other services within CFTLIB.
  -  <img width="502" height="92" alt="Screenshot 2025-11-17 at 09 01 05" src="https://github.com/user-attachments/assets/e190a1e7-32d2-4c12-b510-138340cc5179" />
