### PR TITLE
Exclude multiples API test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,8 @@ tasks.register('functional', Test) {
     testClassesDirs = sourceSets.apiTest.output.classesDirs
     classpath = sourceSets.apiTest.runtimeClasspath
 
+    exclude '**/multiples/**'
+    
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"


### PR DESCRIPTION
### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->
Disable Multiples API tests as it's a non live feature and can be really flakey. Disabling the tests until we pick Multiples back up.