### PR TITLE
Update suppressions.xml

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -45,4 +45,11 @@
     <suppress until="2025-12-10Z">
         <cve>CVE-2025-7962</cve>
     </suppress>
+     <suppress>
+       <notes><![CDATA[
+       file name: angus-activation-2.0.2.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus\-activation@.*$</packageUrl>
+       <cve>CVE-2025-7962</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Update suppressions.xml as upgrading to newer library (https://github.com/hmcts/et-ccd-callbacks/pull/2929) still has the CVE which is being bought in by other libraries and common components being used
<img width="645" height="452" alt="Screenshot 2025-12-10 at 11 19 25" src="https://github.com/user-attachments/assets/02793b66-4d73-4a00-9977-48ea95abc91a" />
