### PR TITLE
Fix case note date using Europe/London timezone

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseNotesService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseNotesService.java
@@ -14,10 +14,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Constants.EUROPE_LONDON;
 
 /**
  * Service for managing case notes in multiple data and case data.
@@ -64,6 +66,7 @@ public class CaseNotesService {
 
     private GenericTypeItem<CaseNote> getCaseNoteGenericTypeItem(String userToken, CaseNote caseNote) {
         DateFormat formatter = new SimpleDateFormat("dd MMM yyyy HH:mm", Locale.ENGLISH);
+        formatter.setTimeZone(TimeZone.getTimeZone(EUROPE_LONDON));
         caseNote.setDate(formatter.format(new Date()));
 
         try {

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/multiples/CaseNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/multiples/CaseNotesServiceTest.java
@@ -14,14 +14,23 @@ import uk.gov.hmcts.ethos.replacement.docmosis.helpers.MultipleUtil;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.CaseNotesService;
 import uk.gov.hmcts.ethos.replacement.docmosis.service.UserIdamService;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ethos.replacement.docmosis.helpers.Constants.EUROPE_LONDON;
 
 @ExtendWith(SpringExtension.class)
 class CaseNotesServiceTest {
@@ -109,6 +118,28 @@ class CaseNotesServiceTest {
         assertEquals(NAME, createdNote.getAuthor());
         assertNotNull(createdNote.getDate());
         assertNull(caseData.getAddCaseNote());
+    }
+
+    @Test
+    void verifyDateIsFormattedInEuropeLondonTimezone() throws ParseException {
+        CaseData caseData = new CaseData();
+        caseData.setAddCaseNote(caseNote);
+        caseNotesService.addCaseNote(caseData, userToken);
+
+        String dateStr = caseData.getCaseNotesCollection().getFirst().getValue().getDate();
+        assertNotNull(dateStr);
+
+        SimpleDateFormat formatter = new SimpleDateFormat("dd MMM yyyy HH:mm", Locale.ENGLISH);
+        formatter.setTimeZone(TimeZone.getTimeZone(EUROPE_LONDON));
+        Date parsedDate = formatter.parse(dateStr);
+
+        ZonedDateTime londonNow = ZonedDateTime.now(ZoneId.of(EUROPE_LONDON));
+        LocalDateTime parsedLocal = parsedDate.toInstant()
+                .atZone(ZoneId.of(EUROPE_LONDON)).toLocalDateTime();
+
+        // Parsed date should be within 1 minute of now in Europe/London time
+        assertEquals(londonNow.getHour(), parsedLocal.getHour());
+        assertEquals(londonNow.getMinute(), parsedLocal.getMinute());
     }
 
     @Test


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/RET-6426

## Summary

Case notes were recording dates using the pod's system timezone (UTC/GMT). During BST, this caused timestamps to appear one hour behind UK local time.

## Changes

- Set `Europe/London` timezone on the `SimpleDateFormat` in `CaseNotesService` so dates are always recorded in UK local time, correctly handling both GMT and BST.
- Added unit test `verifyDateIsFormattedInEuropeLondonTimezone` to assert the saved date reflects the correct `Europe/London` time.

## Notes

The app already sets the JVM default timezone to `Europe/London` via `@PostConstruct` in `DocmosisApplication`, but the explicit `setTimeZone` on the formatter is retained for clarity and to guard against any code executing before `@PostConstruct` runs.