### PR TITLE
Fix: Move JVM timezone initialisation to main() to ensure Europe/London is set before Spring context starts

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/DocmosisApplication.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/DocmosisApplication.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ethos.replacement.docmosis;
 
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -40,6 +39,7 @@ public class DocmosisApplication implements CommandLineRunner {
 
     @SuppressWarnings("PMD.CloseResource") // Context is intentionally closed only when TASK_NAME env var is set
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone(EUROPE_LONDON));
         final var application = new SpringApplication(DocmosisApplication.class);
         final var instance = application.run(args);
 
@@ -59,8 +59,4 @@ public class DocmosisApplication implements CommandLineRunner {
         this.taskRunner = taskRunner;
     }
 
-    @PostConstruct
-    public void init() {
-        TimeZone.setDefault(TimeZone.getTimeZone(EUROPE_LONDON));
-    }
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/DocmosisApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/DocmosisApplicationTest.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.ethos.replacement.docmosis;
 
-import com.ibm.icu.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.TimeZone;
 
 @ExtendWith(SpringExtension.class)
 class DocmosisApplicationTest {
@@ -20,10 +21,7 @@ class DocmosisApplicationTest {
     }
 
     @Test
-    void setsDefaultTimeZoneToEuropeLondonOnInit() {
-        DocmosisApplication application = new DocmosisApplication();
-        application.init();
-
+    void getDefaultTimeZoneIsLondon() {
         assert (TimeZone.getDefault().getID().equalsIgnoreCase("Europe/London"));
     }
 }


### PR DESCRIPTION
## Problem

Deployed pods run with a system timezone of UTC/GMT. The previous approach used `@PostConstruct` on `DocmosisApplication` to call `TimeZone.setDefault(Europe/London)`. However, `@PostConstruct` runs **after** Spring has already begun constructing beans — any bean initialised before `DocmosisApplication`'s post-construct fires (via static initialisers, field defaults, or bean constructors) would capture the pod's UTC timezone instead of Europe/London.

This meant that during BST (British Summer Time, UTC+1), any date formatting relying on the JVM default timezone would record timestamps one hour behind the correct UK local time.

## Solution

Move `TimeZone.setDefault(TimeZone.getTimeZone(EUROPE_LONDON))` to the **very first line of `main()`**, before `SpringApplication.run(args)` is called. This guarantees the JVM default is set to `Europe/London` before any class is loaded or bean is constructed by Spring, correctly handling both GMT (winter) and BST (summer).

## Changes

### `DocmosisApplication.java`
- Removed `@PostConstruct` method `init()` and its `jakarta.annotation.PostConstruct` import
- Added `TimeZone.setDefault(TimeZone.getTimeZone(EUROPE_LONDON))` as the first statement in `main()`

### `DocmosisApplicationTest.java`
- Replaced unused `com.ibm.icu.util.TimeZone` import with `java.util.TimeZone`
- Removed the now-deleted `init()` call from the timezone test