### PR TITLE
Allows postgres_fdw ext to be enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,7 @@ dependencies {
     implementation group: 'org.apache.santuario', name: 'xmlsec', version: '4.0.4'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion
-    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.5.3'
+    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.5.9'
     //To Remove vulnerability CVE-2020-11988
     implementation group: 'org.apache.xmlgraphics', name: 'xmlgraphics-commons', version: '2.11'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.22.3'

--- a/et-shared/build.gradle
+++ b/et-shared/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.5"
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.12"
     }
     dependencies {
         dependency 'commons-fileupload:commons-fileupload:1.6.0'
@@ -139,7 +139,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.18.3'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.3'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.18.3'
-    implementation group: 'org.springframework', name: 'spring-core', version: '6.2.11'
+    implementation group: 'org.springframework', name: 'spring-core', version: '6.2.17'
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.42'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.42'
@@ -158,7 +158,7 @@ dependencies {
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.7'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.19.0'
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.19.0'
-    testImplementation group: 'org.springframework', name: 'spring-test', version: '6.2.10'
+    testImplementation group: 'org.springframework', name: 'spring-test', version: '6.2.17'
     testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
 }
 

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -18,6 +18,12 @@ module "postgres" {
   pgsql_version                  = "15"
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
+  pgsql_server_configuration     = [
+    {
+      name  = "azure.extensions"
+      value = "postgres_fdw"
+    }
+  ]
 }
 
 resource "azurerm_key_vault_secret" "et_cos_postgres_user_v15" {

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -1,4 +1,15 @@
 # ET COS FlexiDB
+locals {
+  db_base_config = [
+    {
+      name  = "azure.extensions"
+      value = "postgres_fdw"
+    }
+  ]
+
+  db_config = var.env == "aat" ? local.db_base_config : []
+}
+
 module "postgres" {
   source = "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"
   env    = var.env
@@ -18,12 +29,7 @@ module "postgres" {
   pgsql_version                  = "15"
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
-  pgsql_server_configuration = [
-    {
-      name  = "azure.extensions"
-      value = "postgres_fdw"
-    }
-  ]
+  pgsql_server_configuration     = local.db_config
 }
 
 resource "azurerm_key_vault_secret" "et_cos_postgres_user_v15" {

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -18,7 +18,7 @@ module "postgres" {
   pgsql_version                  = "15"
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
-  pgsql_server_configuration     = [
+  pgsql_server_configuration = [
     {
       name  = "azure.extensions"
       value = "postgres_fdw"

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -12,7 +12,7 @@ locals {
       name  = "azure.extensions"
       value = "postgres_fdw"
     }
-  ]
+  ])
 }
 
 module "postgres" {

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -2,12 +2,17 @@
 locals {
   db_base_config = [
     {
+      "name" : "backslash_quote",
+      "value" : "on"
+    }
+  ]
+
+  db_config = var.env != "aat" ? local.db_base_config : concat(local.db_base_config, [
+    {
       name  = "azure.extensions"
       value = "postgres_fdw"
     }
   ]
-
-  db_config = var.env == "aat" ? local.db_base_config : []
 }
 
 module "postgres" {


### PR DESCRIPTION
### Jira link

See [CFTD-55](https://tools.hmcts.net/jira/browse/CFTD-55)

### Change description

Allows the postgres_fdw Postgres extension to be enabled so we can spike data migration from CCD to ET as part of the decentralisation work.