### PR TITLE
Fix CVE-2026-22731 and CVE-2026-22732

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,8 @@ dependencies {
     implementation group: 'org.apache.santuario', name: 'xmlsec', version: '4.0.4'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion
-    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.5.3'
+    // CVE-2026-22732
+    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.5.9'
     //To Remove vulnerability CVE-2020-11988
     implementation group: 'org.apache.xmlgraphics', name: 'xmlgraphics-commons', version: '2.11'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.22.3'

--- a/et-shared/build.gradle
+++ b/et-shared/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.5"
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.12"
     }
     dependencies {
         dependency 'commons-fileupload:commons-fileupload:1.6.0'


### PR DESCRIPTION
## What this PR does

Fixes two Spring CVEs detected in the pipeline:

### CVE-2026-22731 (CVSS 8.2 High) — Spring Boot Actuator Authentication Bypass
- **Fix:** Bump Spring Boot BOM in `et-shared/build.gradle` from `3.5.5` → `3.5.12`
- Affected versions: Spring Boot 3.5.0–3.5.11. Fixed in 3.5.12.

### CVE-2026-22732 (CVSS 9.1 Critical) — Spring Security HTTP Headers Not Written
- **Fix:** Bump `spring-security-crypto` in `build.gradle` from `6.5.3` → `6.5.9`
- Affected versions: Spring Security 6.5.0–6.5.8. Fixed in 6.5.9.

## Root cause

`et-shared/build.gradle` imported the Spring Boot BOM at `3.5.5`, which Gradle's dependency resolution caused to win over the main project's Spring Boot plugin version, resulting in vulnerable 3.5.x jars on the classpath. `spring-security-crypto` was explicitly pinned outside the BOM at the vulnerable `6.5.3`.

---

Co-Authored-By: Oz <oz-agent@warp.dev>