### PR TITLE
Fix: Treat 400 Bad Request as non-retryable in UpdateCaseQueueProcessor

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/messagequeue/UpdateCaseQueueProcessor.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/messagequeue/UpdateCaseQueueProcessor.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.messagequeue.QueueMessageStatus;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.messagequeue.UpdateCaseQueueMessage;
@@ -144,6 +145,17 @@ public class UpdateCaseQueueProcessor {
         log.error("Error processing update-case message {}: {}",
                 queueMessage.getMessageId(), exception.getMessage(), exception);
 
+        if (isNonRetryableClientError(exception)) {
+            updateCaseQueueRepository.markAsFailed(
+                    queueMessage.getMessageId(),
+                    exception.getMessage(),
+                    queueMessage.getRetryCount() + 1,
+                    QueueMessageStatus.FAILED,
+                    LocalDateTime.now()
+            );
+            return;
+        }
+
         int newRetryCount = queueMessage.getRetryCount() + 1;
         boolean isLastRetry = newRetryCount >= MAX_RETRIES;
         
@@ -193,6 +205,12 @@ public class UpdateCaseQueueProcessor {
         checkIfFinishWhenError(updateCaseMsg);
     }
     
+    private boolean isNonRetryableClientError(Exception ex) {
+        return ex instanceof HttpClientErrorException httpException
+                && (httpException.getStatusCode().value() == 422
+                    || httpException.getStatusCode().value() == 400);
+    }
+
     private void checkIfFinishWhenError(UpdateCaseMsg updateCaseMsg) {
         try {
             log.info("Adding unrecoverable error to database");

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/messagequeue/UpdateCaseQueueProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/service/messagequeue/UpdateCaseQueueProcessorTest.java
@@ -8,7 +8,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
 import uk.gov.hmcts.ecm.common.model.servicebus.datamodel.CloseDataModel;
 import uk.gov.hmcts.ethos.replacement.docmosis.domain.messagequeue.QueueMessageStatus;
@@ -17,6 +20,7 @@ import uk.gov.hmcts.ethos.replacement.docmosis.domain.repository.messagequeue.Up
 import uk.gov.hmcts.ethos.replacement.docmosis.service.messagehandler.UpdateManagementService;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -121,6 +125,64 @@ class UpdateCaseQueueProcessorTest {
                 any()
         );
         verify(updateManagementService).addUnrecoverableErrorToDatabase(msg);
+    }
+
+    @Test
+    void shouldHandleBadRequestWithNoRetry() throws Exception {
+        // Given
+        UpdateCaseMsg msg = generateUpdateCaseMsg();
+        UpdateCaseQueueMessage queueMessage = createQueueMessage(msg);
+
+        HttpClientErrorException exception = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                "Bad Request",
+                HttpHeaders.EMPTY,
+                "{\"message\":\"No value specified for terms query\"}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8
+        );
+
+        // When
+        processor.handleError(queueMessage, exception);
+
+        // Then - marked as FAILED immediately with no retry logic
+        verify(updateCaseQueueRepository).markAsFailed(
+                eq(queueMessage.getMessageId()),
+                anyString(),
+                eq(1),
+                eq(QueueMessageStatus.FAILED),
+                any()
+        );
+        verify(updateManagementService, never()).addUnrecoverableErrorToDatabase(any());
+        verify(updateManagementService, never()).checkIfFinish(any());
+    }
+
+    @Test
+    void shouldHandleUnprocessableEntityWithNoRetry() throws Exception {
+        // Given
+        UpdateCaseMsg msg = generateUpdateCaseMsg();
+        UpdateCaseQueueMessage queueMessage = createQueueMessage(msg);
+
+        HttpClientErrorException exception = HttpClientErrorException.create(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "Unprocessable Entity",
+                HttpHeaders.EMPTY,
+                "{\"message\":\"Validation failed\"}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8
+        );
+
+        // When
+        processor.handleError(queueMessage, exception);
+
+        // Then - marked as FAILED immediately with no retry logic
+        verify(updateCaseQueueRepository).markAsFailed(
+                eq(queueMessage.getMessageId()),
+                anyString(),
+                eq(1),
+                eq(QueueMessageStatus.FAILED),
+                any()
+        );
+        verify(updateManagementService, never()).addUnrecoverableErrorToDatabase(any());
+        verify(updateManagementService, never()).checkIfFinish(any());
     }
 
     @Test


### PR DESCRIPTION
## Problem

When an `UpdateCaseMsg` arrives with a null `ethosCaseReference` (caused by an empty string being omitted during serialisation due to the `NON_EMPTY` Jackson config), the Elasticsearch `terms` query is built with a null value, resulting in a `400 Bad Request`:

```
[{"type":"parsing_exception","reason":"No value specified for terms query"}]
```

This is a non-recoverable error — retrying will always produce the same result — but the processor was treating it as a transient failure and retrying up to `MAX_RETRIES` times.

## Fix

- Added `isNonRetryableClientError()` which returns `true` for HTTP 400 and 422
- Short-circuited `handleError()` to immediately mark the message `FAILED` for these status codes, skipping all retry and `checkIfFinishWhenError` logic
- Added tests: `shouldHandleBadRequestWithNoRetry` and `shouldHandleUnprocessableEntityWithNoRetry`

## Changes

- `UpdateCaseQueueProcessor.java` — add non-retryable check covering 400 and 422
- `UpdateCaseQueueProcessorTest.java` — add tests for both non-retryable status codes

---
_Conversation: https://app.warp.dev/conversation/b0a86c82-b050-4c6b-aa1d-bc36d1961f69_