### PR TITLE
Flatten PDF AcroForm to fix cross-platform rendering inconsistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,7 @@ dependencies {
     implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.4.2'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
-    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.0-RC1'
+    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.7'
     implementation group: 'org.apache.santuario', name: 'xmlsec', version: '4.0.4'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion

--- a/et-shared/build.gradle
+++ b/et-shared/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.5.0'
     implementation group: 'com.google.guava', name: 'guava', version: '33.6.0-jre'
     implementation group: 'org.apache.tika', name: 'tika-core', version: '3.2.3'
-    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.0-RC1'
+    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.7'
 
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'

--- a/et-shared/src/main/java/uk/gov/hmcts/ecm/common/service/pdf/PdfService.java
+++ b/et-shared/src/main/java/uk/gov/hmcts/ecm/common/service/pdf/PdfService.java
@@ -9,6 +9,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.springframework.stereotype.Service;
@@ -79,21 +80,21 @@ public class PdfService {
                 : cl.getResourceAsStream(pdfSource);
         if (!ObjectUtils.isEmpty(stream)) {
             try (PDDocument pdfDocument = Loader.loadPDF(
-                Objects.requireNonNull(stream))) {
-                Set<Map.Entry<String, Optional<String>>> pdfEntriesMap =
-                        buildPdfEntriesMap(caseData, pdfType, clientType, event);
+                Objects.requireNonNull(stream.readAllBytes()))) {
                 PDDocumentCatalog pdDocumentCatalog = pdfDocument.getDocumentCatalog();
                 PDAcroForm pdfForm = pdDocumentCatalog.getAcroForm();
                 PDResources defaultResources = pdfForm.getDefaultResources();
                 defaultResources.put(COSName.getPDFName(TIMES_NEW_ROMAN_PDFBOX_CHARACTER_CODE),
-                        PDType1Font.TIMES_ROMAN);
+                        new PDType1Font(Standard14Fonts.FontName.TIMES_ROMAN));
                 defaultResources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_1),
-                        PDType1Font.HELVETICA);
+                        new PDType1Font(Standard14Fonts.FontName.HELVETICA));
                 defaultResources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_2),
-                        PDType1Font.HELVETICA);
+                        new PDType1Font(Standard14Fonts.FontName.HELVETICA));
+                Set<Map.Entry<String, Optional<String>>> pdfEntriesMap =
+                        buildPdfEntriesMap(caseData, pdfType, clientType, event);
                 applyPdfEntries(pdfForm, pdfEntriesMap, caseData);
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                pdfForm.setNeedAppearances(true);
+                pdfForm.flatten();
                 pdfDocument.save(byteArrayOutputStream);
                 return byteArrayOutputStream.toByteArray();
             } finally {

--- a/et-shared/src/test/java/uk/gov/hmcts/ecm/common/service/pdf/PdfServiceTest.java
+++ b/et-shared/src/test/java/uk/gov/hmcts/ecm/common/service/pdf/PdfServiceTest.java
@@ -5,10 +5,8 @@ import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
-import org.apache.pdfbox.pdmodel.interactive.form.PDField;
-import org.apache.pdfbox.pdmodel.interactive.form.PDNonTerminalField;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.tika.Tika;
-import org.elasticsearch.core.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +26,6 @@ import uk.gov.hmcts.ecm.common.service.pdf.et1.GenericServiceUtil;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -79,32 +76,19 @@ class PdfServiceTest {
                 SUBMIT_ET1
         );
         try (PDDocument actualPdf = Loader.loadPDF(pdfBytes)) {
-            Map<String, Optional<String>> actualPdfValues = processPdf(actualPdf);
-            PDF_VALUES.forEach((k, v) -> assertThat(actualPdfValues).containsEntry(k, v));
+            // After flattening, interactive fields are converted to static page content
+            PDDocumentCatalog catalog = actualPdf.getDocumentCatalog();
+            PDAcroForm acroForm = catalog.getAcroForm();
+            assertThat(acroForm == null || acroForm.getFields().isEmpty())
+                    .as("AcroForm should have no interactive fields after flattening")
+                    .isTrue();
+            // Verify field values are baked into the page as static text
+            String pageText = new PDFTextStripper().getText(actualPdf);
+            PDF_VALUES.values().stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(value -> assertThat(pageText).contains(value));
         }
-    }
-
-    private Map<String, Optional<String>> processPdf(PDDocument pdDocument) {
-        PDDocumentCatalog pdDocumentCatalog = pdDocument.getDocumentCatalog();
-        PDAcroForm pdfForm = pdDocumentCatalog.getAcroForm();
-        Map<String, Optional<String>> returnFields = new ConcurrentHashMap<>();
-        pdfForm.getFields().forEach(
-            field -> {
-                Tuple<String, String> fieldTuple = processField(field);
-                returnFields.put(fieldTuple.v1(), Optional.ofNullable(fieldTuple.v2()));
-            }
-        );
-        return returnFields;
-    }
-
-    private Tuple<String, String> processField(PDField field) {
-        if (field instanceof PDNonTerminalField) {
-            for (PDField child : ((PDNonTerminalField) field).getChildren()) {
-                processField(child);
-            }
-        }
-
-        return new Tuple<>(field.getFullyQualifiedName(), field.getValueAsString());
     }
 
     @SneakyThrows

--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/pdf/PdfBoxService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/pdf/PdfBoxService.java
@@ -10,6 +10,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.springframework.stereotype.Service;
@@ -133,9 +134,12 @@ public class PdfBoxService {
         if (stream != null) {
             try (PDDocument pdfDocument = Loader.loadPDF(Objects.requireNonNull(stream.readAllBytes()))) {
                 PDResources resources = new PDResources();
-                resources.put(COSName.getPDFName(TIMES_NEW_ROMAN_PDFBOX_CHARACTER_CODE), PDType1Font.TIMES_ROMAN);
-                resources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_1), PDType1Font.HELVETICA);
-                resources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_2), PDType1Font.HELVETICA);
+                resources.put(COSName.getPDFName(TIMES_NEW_ROMAN_PDFBOX_CHARACTER_CODE),
+                        new PDType1Font(Standard14Fonts.FontName.TIMES_ROMAN));
+                resources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_1),
+                        new PDType1Font(Standard14Fonts.FontName.HELVETICA));
+                resources.put(COSName.getPDFName(HELVETICA_PDFBOX_CHARACTER_CODE_2),
+                        new PDType1Font(Standard14Fonts.FontName.HELVETICA));
                 PDDocumentCatalog pdDocumentCatalog = pdfDocument.getDocumentCatalog();
                 PDAcroForm pdfForm = pdDocumentCatalog.getAcroForm();
                 pdfForm.setDefaultResources(resources);
@@ -147,7 +151,7 @@ public class PdfBoxService {
                     }
                 }
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                pdfForm.setNeedAppearances(true);
+                pdfForm.flatten();
                 pdfDocument.save(byteArrayOutputStream);
                 return byteArrayOutputStream.toByteArray();
             } catch (GenericServiceException e) {


### PR DESCRIPTION
## Problem

ET1 and ET3 PDFs rendered differently on Windows vs Mac. Windows users opening the PDF in Edge or Chrome saw section 8.2 (claim description) vertically centred with large blank space at the top and text cut off on the right.

## Root Cause

Both `PdfService` and `PdfBoxService` called `pdfForm.setNeedAppearances(true)` before saving. This tells each PDF viewer to re-render form field appearances itself, and different viewers (Mac Preview/Adobe vs Windows Edge/Chrome) implement this rendering differently — including different defaults for vertical alignment and font metrics.

## Fix

- Replaced `setNeedAppearances(true)` with `pdfForm.flatten()` in both services. Flattening converts interactive AcroForm fields to static page content, so every viewer renders identical output regardless of platform.
- Upgraded PDFBox from `3.0.0-RC1` (release candidate) to `3.0.7` (stable), which includes significant improvements to `PDAcroForm.flatten()`. Required two API migration fixes:
  - `Loader.loadPDF(InputStream)` removed — replaced with `stream.readAllBytes()`
  - `PDType1Font.TIMES_ROMAN` / `PDType1Font.HELVETICA` static constants removed — replaced with `new PDType1Font(Standard14Fonts.FontName.X)`

## Test Changes

Updated `PdfServiceTest.givenPdfValuesProducesAPdfDocument` to reflect the new behaviour — instead of reading values back from AcroForm fields (which no longer exist post-flatten), it now:
1. Asserts the AcroForm has no interactive fields (confirming flatten worked)
2. Uses `PDFTextStripper` to assert the values are present as static text in the document