### PR TITLE
RET-6532

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
@@ -5,53 +5,6 @@ import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.ANONYMITY_ORDER;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_FOR_A_JUDGMENT_TO_BE_RECONSIDERED_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_FOR_A_JUDGMENT_TO_BE_RECONSIDERED_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_FOR_A_WITNESS_ORDER_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_FOR_A_WITNESS_ORDER_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_AMEND_CLAIM;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_AMEND_RESPONSE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_EXTEND_TIME_TO_COMPLY_TO_AN_ORDER_DIRECTIONS_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_EXTEND_TIME_TO_COMPLY_TO_AN_ORDER_DIRECTIONS_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_EXTEND_TIME_TO_PRESENT_A_RESPONSE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_HAVE_A_LEGAL_OFFICER_DECISION_CONSIDERED_AFRESH_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_HAVE_A_LEGAL_OFFICER_DECISION_CONSIDERED_AFRESH_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_ORDER_THE_C_TO_DO_SOMETHING;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_ORDER_THE_R_TO_DO_SOMETHING;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_POSTPONE_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_POSTPONE_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_RESTRICT_PUBLICITY_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_RESTRICT_PUBLICITY_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_REVOKE_AN_ORDER_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_REVOKE_AN_ORDER_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_STRIKE_OUT_ALL_OR_PART_OF_THE_CLAIM;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_STRIKE_OUT_ALL_OR_PART_OF_THE_RESPONSE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_VARY_AN_ORDER_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_VARY_AN_ORDER_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_VARY_OR_REVOKE_AN_ORDER_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.APP_TO_VARY_OR_REVOKE_AN_ORDER_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.CHANGE_OF_PARTYS_DETAILS;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.CONTACT_THE_TRIBUNAL_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.CONTACT_THE_TRIBUNAL_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.COT3;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.COUNTER_SCHEDULE_OF_LOSS;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.C_HAS_NOT_COMPLIED_WITH_AN_ORDER_R;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.ET1_VETTING;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.ET3_PROCESSING;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.EXTRACT_OF_JUDGMENT;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.HEARING_BUNDLE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.INITIAL_CONSIDERATION;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.OTHER;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.REFERRAL_JUDICIAL_DIRECTION;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.R_HAS_NOT_COMPLIED_WITH_AN_ORDER_C;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.SCHEDULE_OF_LOSS;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.TRIBUNAL_CASE_FILE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.TSE_ADMIN_CORRESPONDENCE;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.WITHDRAWAL_OF_ALL_OR_PART_CLAIM;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.WITHDRAWAL_OF_ENTIRE_CLAIM;
-import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.WITHDRAWAL_OF_PART_OF_CLAIM;
-
 /**
  * Defines attributes used by et-sya-api as constants.
  */
@@ -127,21 +80,7 @@ public final class EtSyaConstants {
     public static final String PDF_FILE_TIKA_CONTENT_TYPE = "application/pdf";
     public static final String STRING_DASH = "-";
 
-    public static final List<String> ACAS_HIDDEN_DOCS = List.of(ET1_VETTING, ET3_PROCESSING, INITIAL_CONSIDERATION,
-        APP_FOR_A_WITNESS_ORDER_C, APP_FOR_A_WITNESS_ORDER_R, REFERRAL_JUDICIAL_DIRECTION, COT3,
-        APP_TO_RESTRICT_PUBLICITY_C, APP_TO_RESTRICT_PUBLICITY_R, ANONYMITY_ORDER, HEARING_BUNDLE, SCHEDULE_OF_LOSS,
-        COUNTER_SCHEDULE_OF_LOSS, EXTRACT_OF_JUDGMENT, APP_FOR_A_JUDGMENT_TO_BE_RECONSIDERED_C,
-        APP_FOR_A_JUDGMENT_TO_BE_RECONSIDERED_R, TRIBUNAL_CASE_FILE, OTHER, APP_TO_VARY_AN_ORDER_C,
-        APP_TO_VARY_AN_ORDER_R, APP_TO_REVOKE_AN_ORDER_C, APP_TO_REVOKE_AN_ORDER_R, APP_TO_VARY_OR_REVOKE_AN_ORDER_C,
-        APP_TO_VARY_OR_REVOKE_AN_ORDER_R, APP_TO_EXTEND_TIME_TO_COMPLY_TO_AN_ORDER_DIRECTIONS_C,
-        APP_TO_EXTEND_TIME_TO_COMPLY_TO_AN_ORDER_DIRECTIONS_R, APP_TO_ORDER_THE_R_TO_DO_SOMETHING,
-        APP_TO_ORDER_THE_C_TO_DO_SOMETHING, APP_TO_AMEND_CLAIM, APP_TO_AMEND_RESPONSE,
-        R_HAS_NOT_COMPLIED_WITH_AN_ORDER_C, C_HAS_NOT_COMPLIED_WITH_AN_ORDER_R,
-        APP_TO_STRIKE_OUT_ALL_OR_PART_OF_THE_CLAIM, APP_TO_STRIKE_OUT_ALL_OR_PART_OF_THE_RESPONSE,
-        APP_TO_HAVE_A_LEGAL_OFFICER_DECISION_CONSIDERED_AFRESH_C, APP_TO_EXTEND_TIME_TO_PRESENT_A_RESPONSE,
-        APP_TO_HAVE_A_LEGAL_OFFICER_DECISION_CONSIDERED_AFRESH_R, APP_TO_POSTPONE_C, APP_TO_POSTPONE_R,
-        CONTACT_THE_TRIBUNAL_C, CONTACT_THE_TRIBUNAL_R, TSE_ADMIN_CORRESPONDENCE, CHANGE_OF_PARTYS_DETAILS,
-        WITHDRAWAL_OF_ENTIRE_CLAIM, WITHDRAWAL_OF_PART_OF_CLAIM, WITHDRAWAL_OF_ALL_OR_PART_CLAIM);
+    public static final List<String> ACAS_VISIBLE_DOCS = List.of(ET1, ET1_ATTACHMENT, ET3, ET3_ATTACHMENT);
 
     private EtSyaConstants() {
         // restrict instantiation

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +19,6 @@ import uk.gov.hmcts.reform.et.syaapi.service.AdminUserService;
 import uk.gov.hmcts.reform.et.syaapi.service.CaseDocumentService;
 import uk.gov.hmcts.reform.et.syaapi.service.FeatureToggleService;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -55,8 +53,7 @@ public class AcasController {
     @RequiresAcasRole
     public ResponseEntity<Object> getLastModifiedCaseList(
         @RequestHeader(value = HttpHeaders.AUTHORIZATION) String userToken,
-        @RequestParam(name = "datetime")
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestDateTime) {
+        @RequestParam(name = "datetime") String requestDateTime) {
         return ok(acasCaseService.getLastModifiedCasesId(userToken, requestDateTime));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
@@ -74,7 +74,7 @@ public class AcasCaseService {
      * @param requestDateTime used as the query parameter; must represent a UTC datetime
      * @return a list of caseIds
      */
-    public List<Long> getLastModifiedCasesId(String authorisation, LocalDateTime requestDateTime) {
+    public List<Long> getLastModifiedCasesId(String authorisation, String requestDateTime) {
         String query = """
             {
               "size": %d,
@@ -102,7 +102,8 @@ public class AcasCaseService {
                 "reference"
               ]
             }
-            """.formatted(MAX_ES_SIZE, requestDateTime.atOffset(ZoneOffset.UTC).toInstant().toString());
+            """.formatted(MAX_ES_SIZE,
+            LocalDateTime.parse(requestDateTime).atOffset(ZoneOffset.UTC).toInstant().toString());
         return searchEnglandScotlandCases(authorisation, query)
             .stream()
             .map(CaseDetails::getId)

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
@@ -26,17 +26,19 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.postgresql.shaded.com.ongres.scram.common.util.Preconditions.isNullOrEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MAX_ES_SIZE;
-import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_HIDDEN_DOCS;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_VISIBLE_DOCS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ENGLAND_CASE_TYPE;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET1_ATTACHMENT;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET3;
@@ -65,10 +67,11 @@ public class AcasCaseService {
 
     /**
      * Given a datetime, this method will return a list of caseIds which have been modified since the datetime
-     * provided.
+     * provided. The {@code requestDateTime} is treated as UTC regardless of the JVM's default timezone,
+     * ensuring consistent behaviour across environments and during BST/GMT transitions.
      *
      * @param authorisation   used for IDAM authentication for the query
-     * @param requestDateTime used as the query parameter
+     * @param requestDateTime used as the query parameter; must represent a UTC datetime
      * @return a list of caseIds
      */
     public List<Long> getLastModifiedCasesId(String authorisation, LocalDateTime requestDateTime) {
@@ -99,7 +102,7 @@ public class AcasCaseService {
                 "reference"
               ]
             }
-            """.formatted(MAX_ES_SIZE, requestDateTime.toString());
+            """.formatted(MAX_ES_SIZE, requestDateTime.atOffset(ZoneOffset.UTC).toInstant().toString());
         return searchEnglandScotlandCases(authorisation, query)
             .stream()
             .map(CaseDetails::getId)
@@ -150,7 +153,7 @@ public class AcasCaseService {
 
     private void addDocumentsToMap(String authorisation, List<CaseDocumentAcasResponse> documents,
                                    List<DocumentTypeItem> documentTypeItemList) {
-        documentTypeItemList.stream()
+        emptyIfNull(documentTypeItemList).stream()
             .filter(documentTypeItem -> !isDuplicatedDoc(documents, documentTypeItem))
             .forEach(documentTypeItem -> documents.add(caseDocumentAcasResponseBuilder(
                 documentTypeItem,
@@ -172,6 +175,11 @@ public class AcasCaseService {
 
     private List<DocumentTypeItem> getAllCaseDocuments(String authorisation, List<CaseDocumentAcasResponse> documents,
                                                        CaseData caseData) {
+
+        if (checkReceiptDateForAcas(caseData)) {
+            return new ArrayList<>();
+        }
+
         retrieveRespondentDocuments(authorisation, documents, caseData);
 
         List<DocumentTypeItem> documentTypeItemList = new ArrayList<>(getDocumentCollectionDocs(caseData));
@@ -185,13 +193,27 @@ public class AcasCaseService {
         return documentTypeItemList;
     }
 
+    /**
+     * ACAS should not receive documents for cases submitted before 1st April 2026. This is so that they can avoid
+     * having duplicate documents for older cases.
+     * @param caseData the case data
+     * @return true if the receipt date is before 1st April 2026 or if the receipt date is not provided or false if the
+     *     receipt date is on or after 1st April 2026.
+     */
+    private boolean checkReceiptDateForAcas(CaseData caseData) {
+        if (caseData.getReceiptDate() == null) {
+            return true;
+        }
+        return LocalDate.parse(caseData.getReceiptDate()).isBefore(LocalDate.of(2026, 4, 1));
+    }
+
     private static List<DocumentTypeItem> getDocumentCollectionDocs(CaseData caseData) {
         if (CollectionUtils.isEmpty(caseData.getDocumentCollection())) {
             return new ArrayList<>();
         }
 
         return caseData.getDocumentCollection().stream()
-            .filter(d -> !isNullOrEmpty(getDocumentType(d)) && !ACAS_HIDDEN_DOCS.contains(getDocumentType(d)))
+            .filter(d -> !isNullOrEmpty(getDocumentType(d)) && ACAS_VISIBLE_DOCS.contains(getDocumentType(d)))
             .toList();
     }
 
@@ -296,7 +318,7 @@ public class AcasCaseService {
 
     /**
      * Searches for cases in both England and Scotland case types based on the provided query. Note that this method
-     * is a synchronous operation that combines results from both case types to optimize performance.
+     * is a synchronous operation that combines results from both case types to optimise performance.
      * @param authorisation used for IDAM authentication for the query
      * @param query the query string to search for cases
      * @return a list of case details that match the query from both England and Scotland case types

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasControllerTest.java
@@ -27,8 +27,6 @@ import uk.gov.hmcts.reform.et.syaapi.service.CaseDocumentService;
 import uk.gov.hmcts.reform.et.syaapi.service.FeatureToggleService;
 import uk.gov.hmcts.reform.et.syaapi.service.RoleValidationService;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -92,7 +90,7 @@ class AcasControllerTest {
     @Test
     void getLastModifiedCaseListWhenSuccessCasesFoundReturnList() throws Exception {
         when(acasCaseService.getLastModifiedCasesId(
-            AUTH_TOKEN, LocalDateTime.parse("2022-09-01T12:34:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+            AUTH_TOKEN, "2022-09-01T12:34:00"))
             .thenReturn(List.of(1_646_225_213_651_598L, 1_646_225_213_651_533L, 1_646_225_213_651_512L));
         when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
         mockMvc.perform(get(GET_LAST_MODIFIED_CASE_LIST_URL)

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -173,7 +174,7 @@ class AcasCaseServiceTest {
                 "reference"
               ]
             }
-            """.formatted(Constants.MAX_ES_SIZE, requestDateTime.toString());
+            """.formatted(Constants.MAX_ES_SIZE, requestDateTime.atOffset(ZoneOffset.UTC).toInstant().toString());
     }
 
     @Test
@@ -200,8 +201,7 @@ class AcasCaseServiceTest {
         )).thenReturn(scotlandSearchResult);
 
         List<CaseDetails> caseDetailsList = acasCaseService.getCaseData(TestConstants.TEST_SERVICE_AUTH_TOKEN, caseIds);
-        assertThat(caseDetailsList).hasSize(3);
-        assertThat(caseDetailsList).isEqualTo(testData.getExpectedCaseDataListCombined());
+        assertThat(caseDetailsList).hasSize(3).isEqualTo(testData.getExpectedCaseDataListCombined());
     }
 
     @Test
@@ -253,7 +253,7 @@ class AcasCaseServiceTest {
     }
 
     @Test
-    void retrieveAcasDocuments() {
+    void retrieveAcasDocuments_validReceiptDate() {
         String caseId = EXAMPLE_CASE_ID;
         SearchResult englandWalesSearchResult = SearchResult.builder()
             .total(1)
@@ -282,7 +282,92 @@ class AcasCaseServiceTest {
             .thenReturn(TestDataProvider.getDocumentDetailsFromCdam());
         List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
         assertNotNull(documents);
-        assertThat(documents).hasSize(5);
+        assertThat(documents).hasSize(4);
+    }
+
+    @Test
+    void retrieveAcasDocuments_removedReceiptDate() {
+        String caseId = EXAMPLE_CASE_ID;
+        testData.getRequestCaseDataListEnglandAcas().getFirst().getData().remove("receiptDate");
+        SearchResult englandWalesSearchResult = SearchResult.builder()
+            .total(1)
+            .cases(testData.getRequestCaseDataListEnglandAcas())
+            .build();
+        SearchResult scotlandSearchResult = SearchResult.builder()
+            .total(0)
+            .cases(null)
+            .build();
+
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(englandWalesSearchResult);
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(scotlandSearchResult);
+        List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
+        assertNotNull(documents);
+        assertThat(documents).isEmpty();
+    }
+
+    @Test
+    void retrieveAcasDocuments_nullReceiptDate() {
+        String caseId = EXAMPLE_CASE_ID;
+        testData.getRequestCaseDataListEnglandAcas().getFirst().getData().put("receiptDate", null);
+        SearchResult englandWalesSearchResult = SearchResult.builder()
+            .total(1)
+            .cases(testData.getRequestCaseDataListEnglandAcas())
+            .build();
+        SearchResult scotlandSearchResult = SearchResult.builder()
+            .total(0)
+            .cases(null)
+            .build();
+
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(englandWalesSearchResult);
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(scotlandSearchResult);
+        List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
+        assertNotNull(documents);
+        assertThat(documents).isEmpty();
+    }
+
+    @Test
+    void retrieveAcasDocuments_pastReceiptDate() {
+        String caseId = EXAMPLE_CASE_ID;
+        testData.getRequestCaseDataListEnglandAcas().getFirst().getData().put("receiptDate",
+            LocalDate.of(2026, 3, 31).toString());
+        SearchResult englandWalesSearchResult = SearchResult.builder()
+            .total(1)
+            .cases(testData.getRequestCaseDataListEnglandAcas())
+            .build();
+        SearchResult scotlandSearchResult = SearchResult.builder()
+            .total(0)
+            .cases(null)
+            .build();
+
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(englandWalesSearchResult);
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(scotlandSearchResult);
+        List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
+        assertNotNull(documents);
+        assertThat(documents).isEmpty();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,8 +84,7 @@ class AcasCaseServiceTest {
 
     @Test
     void shouldLastModifiedCasesIdWhenCaseFoundThenCaseId() {
-        LocalDateTime requestDateTime =
-            LocalDateTime.parse("2022-09-01T12:34:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        String requestDateTime = "2022-09-01T12:34:00";
 
         SearchResult englandWalesSearchResult = SearchResult.builder()
             .total(1)
@@ -117,8 +115,7 @@ class AcasCaseServiceTest {
 
     @Test
     void shouldLastModifiedCasesIdWhenNoCaseFoundThenEmpty() {
-        LocalDateTime requestDateTime =
-            LocalDateTime.parse("2022-09-01T12:34:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        String requestDateTime = "2022-09-01T12:34:00";
 
         SearchResult englandWalesSearchResult = SearchResult.builder()
             .total(0)
@@ -146,7 +143,7 @@ class AcasCaseServiceTest {
             .isEmpty();
     }
 
-    private String generateCaseDataEsQueryWithDate(LocalDateTime requestDateTime) {
+    private String generateCaseDataEsQueryWithDate(String requestDateTime) {
         return """
             {
               "size": %d,
@@ -174,7 +171,8 @@ class AcasCaseServiceTest {
                 "reference"
               ]
             }
-            """.formatted(Constants.MAX_ES_SIZE, requestDateTime.atOffset(ZoneOffset.UTC).toInstant().toString());
+            """.formatted(Constants.MAX_ES_SIZE,
+            LocalDateTime.parse(requestDateTime).atOffset(ZoneOffset.UTC).toInstant().toString());
     }
 
     @Test

--- a/src/test/resources/responses/caseDetailsEnglandAcasDocs.json
+++ b/src/test/resources/responses/caseDetailsEnglandAcasDocs.json
@@ -10,6 +10,7 @@
     "security_level": null,
     "case_data": {
       "caseType": "Single",
+      "receiptDate": "2026-04-01",
       "caseSource": "Manually Created",
       "claimantRequests": {
         "claim_description_document": {


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [RET-6532](https://tools.hmcts.net/jira/browse/RET-6532)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

- Update getLastModifiedCaseList to support UTC to cater for BST
- Updated the document visible for ACAS through the API
  - The number of docs has been reduced the lessen the load on their platform as opposed to HMCTS. This will be increased on they have resolved issues on their side
  - Added a receiptDate filter so that any cases submitted after the 1st of April 2026 show docs in the API. Any case submitted before then will not return any docs in the API
