### PR TITLE
RET-6430

### DIFF
--- a/charts/et-cos/values.preview.template.yaml
+++ b/charts/et-cos/values.preview.template.yaml
@@ -75,7 +75,7 @@ et-sya:
   enabled: true
   nodejs:
     imagePullPolicy: Always
-    image: hmctsprod.azurecr.io/et/sya:pr-2408
+    image: hmctsprod.azurecr.io/et/sya:latest
     releaseNameOverride: ${SERVICE_NAME}-et-sya
     ingressHost: et-sya-${SERVICE_FQDN}
     devcpuRequests: 10m
@@ -94,7 +94,7 @@ et-sya:
           - launch-darkly-sdk-key
     environment:
       REDIS_HOST: et-session-storage-aat.redis.cache.windows.net
-      ET_SYA_API_HOST: https://${SERVICE_FQDN}
+      ET_SYA_API_HOST: https://et-sya-api-${SERVICE_FQDN}
       PCQ_ENABLED: true
 
 et-syr:

--- a/charts/et-cos/values.preview.template.yaml
+++ b/charts/et-cos/values.preview.template.yaml
@@ -75,7 +75,7 @@ et-sya:
   enabled: true
   nodejs:
     imagePullPolicy: Always
-    image: hmctsprod.azurecr.io/et/sya:latest
+    image: hmctsprod.azurecr.io/et/sya:pr-2408
     releaseNameOverride: ${SERVICE_NAME}-et-sya
     ingressHost: et-sya-${SERVICE_FQDN}
     devcpuRequests: 10m
@@ -94,7 +94,7 @@ et-sya:
           - launch-darkly-sdk-key
     environment:
       REDIS_HOST: et-session-storage-aat.redis.cache.windows.net
-      ET_SYA_API_HOST: https://et-sya-api-${SERVICE_FQDN}
+      ET_SYA_API_HOST: https://${SERVICE_FQDN}
       PCQ_ENABLED: true
 
 et-syr:

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/DocumentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/DocumentController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.et.syaapi.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ByteArrayResource;
@@ -47,6 +48,26 @@ public class DocumentController {
 
         return caseDocumentService.downloadDocument(authToken, documentId);
     }
+
+    /**
+     * Streams content of the given document id directly from CDAM without buffering.
+     *
+     * @param authToken  jwt token for authentication
+     * @param documentId id for the chosen document
+     * @param response   the HttpServletResponse to write the streamed content to
+     */
+    @GetMapping("/stream/{documentId}")
+    @Operation(summary = "Stream document binary content by id from case document api")
+    @ApiResponse(responseCode = "200", description = "OK")
+    @ApiResponse(responseCode = "404", description = "Case document not found")
+    public void streamDocumentBinaryContent(
+        @PathVariable("documentId") final UUID documentId,
+        @RequestHeader(AUTHORIZATION) String authToken,
+        HttpServletResponse response) {
+        log.info("Called DocumentController streamDocumentBinaryContent");
+        caseDocumentService.streamDocument(authToken, documentId, response);
+    }
+
 
     /**
      * Returns document details in JSON format of the given document id.

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.et.syaapi.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ import uk.gov.hmcts.reform.et.syaapi.config.interceptors.ResourceNotFoundExcepti
 import uk.gov.hmcts.reform.et.syaapi.models.CaseDocument;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -119,7 +121,7 @@ public class CaseDocumentService {
      * @param authToken  the caller's bearer token used to verify the caller
      * @param documentId the id of the document
      * @return the response entity which contains the binary stream
-     * @throws ResourceNotFoundException if the target API returns 404 response code
+     * @throws ResourceNotFoundException if the target API returns a 404 response code
      */
     public ResponseEntity<ByteArrayResource> downloadDocument(String authToken, UUID documentId) {
         log.info("Called downloadDocument");
@@ -152,7 +154,7 @@ public class CaseDocumentService {
      * @param authToken  the caller's bearer token used to verify the caller
      * @param documentId the id of the document
      * @return the response entity which contains the document details object
-     * @throws ResourceNotFoundException if the target API returns 404 response code
+     * @throws ResourceNotFoundException if the target API returns a 404 response code
      */
     public ResponseEntity<CaseDocument> getDocumentDetails(String authToken, UUID documentId) {
         HttpHeaders headers = new HttpHeaders();
@@ -276,18 +278,53 @@ public class CaseDocumentService {
         return body;
     }
 
+    /**
+     * Streams the binary content of the given document id from CDAM directly to the HTTP response.
+     * Headers including Content-Type and Content-Length are forwarded from the CDAM response.
+     *
+     * @param authToken  the caller's bearer token used to verify the caller
+     * @param documentId the id of the document
+     * @param response   the HTTP response to stream the document content to
+     * @throws ResourceNotFoundException if the target API returns a 404 response code
+     */
+    public void streamDocument(String authToken, UUID documentId, HttpServletResponse response) {
+        log.info("Called streamDocument");
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, authToken);
+        headers.add(SERVICE_AUTHORIZATION, authTokenGenerator.generate());
+
+        try {
+            restTemplate.execute(
+                caseDocApiUrl + "/cases/documents/" + documentId + "/binary",
+                HttpMethod.GET,
+                request -> request.getHeaders().putAll(headers),
+                clientResponse -> {
+                    HttpHeaders responseHeaders = clientResponse.getHeaders();
+                    if (responseHeaders.getContentType() != null) {
+                        response.setContentType(responseHeaders.getContentType().toString());
+                    }
+                    if (responseHeaders.getContentLength() > 0) {
+                        response.setContentLengthLong(responseHeaders.getContentLength());
+                    }
+                    try (InputStream inputStream = clientResponse.getBody()) {
+                        inputStream.transferTo(response.getOutputStream());
+                    }
+                    return null;
+                }
+            );
+        } catch (HttpClientErrorException ex) {
+            if (NOT_FOUND.equals(ex.getStatusCode())) {
+                throw new ResourceNotFoundException(
+                    String.format(RESOURCE_NOT_FOUND, documentId, ex.getMessage()), ex);
+            }
+            throw ex;
+        }
+    }
+
     @Data
     private static final class DocumentUploadResponse {
         private List<CaseDocument> documents;
 
-        /**
-         * Accessor for revealing if the response has any documents.
-         *
-         * @return a boolean that is false if documents list is empty
-         */
-        public Boolean isEmpty() {
-            return documents.isEmpty();
-        }
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/DocumentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/DocumentControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.et.syaapi.controllers;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,6 +21,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -96,6 +99,38 @@ class DocumentControllerTest {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value(404))
             .andExpect(jsonPath("$.message").value("Document not found"));
+    }
+
+    @Test
+    void streamDocumentBinaryContentSuccess() throws Exception {
+        byte[] content = "test document content".getBytes();
+        when(verifyTokenService.verifyTokenSignature(any())).thenReturn(true);
+        doAnswer(invocation -> {
+            HttpServletResponse servletResponse = invocation.getArgument(2);
+            servletResponse.setContentType(MediaType.APPLICATION_PDF_VALUE);
+            servletResponse.getOutputStream().write(content);
+            return null;
+        }).when(caseDocumentService).streamDocument(any(), any(), any(HttpServletResponse.class));
+
+        mockMvc.perform(get("/document/stream/" + DOCUMENT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN))
+            .andExpect(status().isOk())
+            .andExpect(content().bytes(content));
+    }
+
+    @Test
+    void streamDocumentBinaryContentResourceNotFound() throws Exception {
+        when(verifyTokenService.verifyTokenSignature(any())).thenReturn(true);
+        doThrow(new ResourceNotFoundException(NOT_FOUND_MESSAGE, null))
+            .when(caseDocumentService).streamDocument(any(), any(), any(HttpServletResponse.class));
+
+        mockMvc.perform(get("/document/stream/" + DOCUMENT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value(NOT_FOUND_MESSAGE));
     }
 
     private ResponseEntity<ByteArrayResource> getDocumentBinaryContent() {

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -564,7 +564,9 @@ class CaseDocumentServiceTest {
             () -> caseDocumentService.streamDocument(MOCK_TOKEN, DOCUMENT_ID, servletResponse));
 
         assertThat(resourceNotFoundException.getMessage())
-            .isEqualTo(String.format(RESOURCE_NOT_FOUND, DOCUMENT_ID, "404 Not Found: [no body]"));
+            .isEqualTo(String.format(RESOURCE_NOT_FOUND, DOCUMENT_ID,
+                "404 Not Found on GET request for \""
+                    + DOCUMENT_API_URL_WITH_SLASH + DOCUMENT_ID + "/binary\": [no body]"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -32,7 +34,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -70,7 +71,6 @@ class CaseDocumentServiceTest {
     private static final Integer MAX_API_CALL_ATTEMPTS = 4;
     private static final String MOCK_FILE_BODY = "Hello, World!";
     private static final UUID DOCUMENT_ID = UUID.randomUUID();
-    private static final Date TEST_DATE = new Date();
     private static final MockMultipartFile MOCK_FILE = new MockMultipartFile(
         "mock_file",
         DOCUMENT_NAME,
@@ -110,12 +110,6 @@ class CaseDocumentServiceTest {
         ".invalid|.xyz",
         MediaType.TEXT_PLAIN_VALUE,
         MOCK_FILE_BODY.getBytes()
-    );
-    private static final MockMultipartFile MOCK_FILE_CORRUPT = new MockMultipartFile(
-        "mock_file_corrupt",
-        DOCUMENT_NAME,
-        MediaType.IMAGE_GIF_VALUE,
-        (byte[]) null
     );
     private static final String RESPONSE_BODY = "{\"documents\":[{\"originalDocumentName\":";
     private static final String MOCK_RESPONSE_WITH_DOCUMENT = RESPONSE_BODY
@@ -238,7 +232,7 @@ class CaseDocumentServiceTest {
 
         mockServer.expect(ExpectedCount.max(MAX_API_CALL_ATTEMPTS), requestTo(DOCUMENT_API_URL))
             .andExpect(method(HttpMethod.POST))
-            .andRespond((response) -> {
+            .andRespond(response -> {
                 throw restClientException;
             });
 
@@ -519,5 +513,70 @@ class CaseDocumentServiceTest {
         assertEquals(createdDoc.getValue().getShortDescription(), documentTypeItem.getValue().getShortDescription());
         assertEquals(createdDoc.getValue().getDateOfCorrespondence(),
                      documentTypeItem.getValue().getDateOfCorrespondence());
+    }
+
+    @Test
+    void streamDocumentSuccess() {
+        byte[] content = "test document content".getBytes();
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        mockServer.expect(ExpectedCount.once(), requestTo(DOCUMENT_API_URL_WITH_SLASH + DOCUMENT_ID + "/binary"))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withStatus(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(content));
+
+        caseDocumentService.streamDocument(MOCK_TOKEN, DOCUMENT_ID, servletResponse);
+
+        assertThat(servletResponse.getContentAsByteArray()).isEqualTo(content);
+        assertThat(servletResponse.getContentType()).isEqualTo(MediaType.APPLICATION_PDF_VALUE);
+    }
+
+    @Test
+    void streamDocumentForwardsContentLength() {
+        byte[] content = "test document content".getBytes();
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setContentLength(content.length);
+
+        mockServer.expect(ExpectedCount.once(), requestTo(DOCUMENT_API_URL_WITH_SLASH + DOCUMENT_ID + "/binary"))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withStatus(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_PDF)
+                .headers(responseHeaders)
+                .body(content));
+
+        caseDocumentService.streamDocument(MOCK_TOKEN, DOCUMENT_ID, servletResponse);
+
+        assertThat(servletResponse.getContentLength()).isEqualTo(content.length);
+    }
+
+    @Test
+    void streamDocumentResourceNotFound() {
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        mockServer.expect(ExpectedCount.once(), requestTo(DOCUMENT_API_URL_WITH_SLASH + DOCUMENT_ID + "/binary"))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        ResourceNotFoundException resourceNotFoundException = assertThrows(
+            ResourceNotFoundException.class,
+            () -> caseDocumentService.streamDocument(MOCK_TOKEN, DOCUMENT_ID, servletResponse));
+
+        assertThat(resourceNotFoundException.getMessage())
+            .isEqualTo(String.format(RESOURCE_NOT_FOUND, DOCUMENT_ID, "404 Not Found: [no body]"));
+    }
+
+    @Test
+    void streamDocumentNonNotFoundHttpErrorIsRethrown() {
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        mockServer.expect(ExpectedCount.once(), requestTo(DOCUMENT_API_URL_WITH_SLASH + DOCUMENT_ID + "/binary"))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withStatus(HttpStatus.FORBIDDEN));
+
+        assertThrows(
+            HttpClientErrorException.class,
+            () -> caseDocumentService.streamDocument(MOCK_TOKEN, DOCUMENT_ID, servletResponse));
     }
 }


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [RET-6430](https://tools.hmcts.net/jira/browse/RET-6430)

### Change description
Add an endpoint to allow document streaming so that bytes are processed as and when received so that large documents are viewable straight away whilst the rest of the data is loaded in the background.

**Note**
This change introduces an API though there is nothing live which currently points to it