### PR TITLE
Fix staging Service Bus secret mapping

### DIFF
--- a/charts/et-cos/Chart.yaml
+++ b/charts/et-cos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: et-cos
 home: https://github.com/hmcts/et-ccd-callbacks
-version: 0.0.63
+version: 0.0.64
 description: HMCTS Employment Tribunals CCD Callbacks service
 maintainers:
   - name: HMCTS Employment Tribunals Team

--- a/charts/et-cos/values.yaml
+++ b/charts/et-cos/values.yaml
@@ -45,6 +45,8 @@ java:
           alias: GOV_NOTIFY_API_KEY
         - name: launch-darkly-sdk-key
           alias: LAUNCH_DARKLY_SDK_KEY
+        - name: ccd-case-events-sendonly-connection-string
+          alias: AZURE_SERVICE_BUS_CONNECTION_STRING
   environment:
     SERVER_PORT: 8081
     REFORM_TEAM: et


### PR DESCRIPTION
## Summary

- map the existing ET Key Vault Service Bus secret to `AZURE_SERVICE_BUS_CONNECTION_STRING`
- allow non-preview deployments to initialise the CCD SDK case-event publisher

## Root cause

The SDK case-event publisher was enabled without wiring the existing staging Service Bus connection string into the application. The application therefore used its `dummy` fallback value, failed to create the JMS connection factory, and entered a crash loop during deployment.

## Impact

Staging and other non-preview deployments can start successfully and publish CCD case events using the existing send-only Service Bus credentials.

## Validation

- parsed `charts/et-cos/values.yaml` successfully as YAML
- `git diff --check`
