### PR TITLE
Fix CFTLIB decentralised route config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -688,13 +688,21 @@ bootWithCCD {
     // et-ccd-callbacks
     //environment 'SERVICEBUS_FAKE', 'true'*
     environment 'CFTLIB_EXTRA_COMPOSE_FILES', ''
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_EnglandWales', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_Scotland', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_EnglandWales_Listings', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_Scotland_Listings', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_EnglandWales_Multiple', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_Scotland_Multiple', 'https://localhost:8081'
-    environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_ET_Admin', 'https://localhost:8081'
+    environment 'SPRING_APPLICATION_JSON', groovy.json.JsonOutput.toJson([
+        ccd: [
+            decentralised: [
+                'case-type-service-urls': [
+                    ET_EnglandWales: 'http://localhost:8081',
+                    ET_Scotland: 'http://localhost:8081',
+                    ET_EnglandWales_Listings: 'http://localhost:8081',
+                    ET_Scotland_Listings: 'http://localhost:8081',
+                    ET_EnglandWales_Multiple: 'http://localhost:8081',
+                    ET_Scotland_Multiple: 'http://localhost:8081',
+                    ET_Admin: 'http://localhost:8081'
+                ]
+            ]
+        ]
+    ])
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
     id 'hmcts.ccd.sdk' version '6.11.0'
-    id 'com.github.hmcts.rse-cft-lib' version '0.19.2134'
+    id 'com.github.hmcts.rse-cft-lib' version '0.19.2194'
 }
 
 group = 'uk.gov.hmcts.et'


### PR DESCRIPTION
Fixes the local CFTLIB CCD decentralised persistence route setup for ET case types.

The previous environment-variable map keys were being relaxed by Spring, so ET_Scotland became et.scotland and did not match the actual ET_Scotland case type. Supplying the map through SPRING_APPLICATION_JSON preserves the underscore case type IDs and routes local CCD persistence back to the ET service over HTTP.
