### PR TITLE
Pin Jenkins library to 2.0.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,6 +99,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
+  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.0.0")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -100,7 +100,8 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
   def puppeteerCacheKey = "${env.JOB_NAME ?: 'job'}-${env.BUILD_NUMBER ?: java.util.UUID.randomUUID().toString()}".replaceAll(/[^A-Za-z0-9_.-]/, '-')
-  env.PUPPETEER_CACHE_DIR = "/tmp/puppeteer-cache-${puppeteerCacheKey}"
+  env.PUPPETEER_CACHE_BASE_DIR = "/tmp/puppeteer-cache-${puppeteerCacheKey}"
+  env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-smoke"
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()
@@ -232,6 +233,7 @@ withPipeline(type, product, component) {
 
       stage('Functional UI tests chromium') {
         try {
+          env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
           env.ET_COS_PREVIEW_ET_SYA_API = "https://et-sya-api-et-cos-pr-${CHANGE_ID}.preview.platform.hmcts.net/"
           env.ET_COS_PREVIEW_CCD = "https://ccd-data-store-api-et-cos-pr-${CHANGE_ID}.preview.platform.hmcts.net/"
           yarnBuilder.yarn('test:functional-chromium')
@@ -293,6 +295,7 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/functional/**/*'
     stage('Functional UI tests chromium') {
       try {
+        env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
         yarnBuilder.yarn('test:functional-chromium')
       } catch (Error) {
         unstable(message: "${STAGE_NAME} is unstable: " + Error.toString())

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,7 +99,8 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
-  env.PUPPETEER_CACHE_DIR = '/tmp/puppeteer-cache'
+  def puppeteerCacheKey = "${env.JOB_NAME ?: 'job'}-${env.BUILD_NUMBER ?: java.util.UUID.randomUUID().toString()}".replaceAll(/[^A-Za-z0-9_.-]/, '-')
+  env.PUPPETEER_CACHE_DIR = "/tmp/puppeteer-cache-${puppeteerCacheKey}"
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,7 +99,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
-  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
+  env.PUPPETEER_CACHE_DIR = '/tmp/puppeteer-cache'
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -227,13 +227,17 @@ withPipeline(type, product, component) {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'et-xui-e2e-tests/playwright-report/**'
     }
 
+    before('functionalTest:preview') {
+      env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
+    }
+
     afterAlways('functionalTest:preview') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/functional/**/*'
 
       stage('Functional UI tests chromium') {
         try {
-          env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
+          env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional-ui"
           env.ET_COS_PREVIEW_ET_SYA_API = "https://et-sya-api-et-cos-pr-${CHANGE_ID}.preview.platform.hmcts.net/"
           env.ET_COS_PREVIEW_CCD = "https://ccd-data-store-api-et-cos-pr-${CHANGE_ID}.preview.platform.hmcts.net/"
           yarnBuilder.yarn('test:functional-chromium')
@@ -290,12 +294,16 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'et-xui-e2e-tests/playwright-report/**'
   }
 
+  before('functionalTest:aat') {
+    env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
+  }
+
   afterAlways('functionalTest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/functional/**/*'
     stage('Functional UI tests chromium') {
       try {
-        env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional"
+        env.PUPPETEER_CACHE_DIR = "${env.PUPPETEER_CACHE_BASE_DIR}-functional-ui"
         yarnBuilder.yarn('test:functional-chromium')
       } catch (Error) {
         unstable(message: "${STAGE_NAME} is unstable: " + Error.toString())


### PR DESCRIPTION
Pins the CNP Jenkins shared library to `Infrastructure@2.0.0`.

The PR Jenkins job is now failing the old library version guard on `Jenkinsfile_CNP`. This change uses the version requested by the guard so PR builds can pass that check.

I checked the migration caveat in the library warning as well. ET already has the flexible Postgres module and v15 Key Vault secrets wired into the Jenkinsfile, so this PR keeps the change to the library pin only.
