### PR TITLE
Bump CCD SDK to 6.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.freefair.lombok' version '8.14.4'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
-    id 'hmcts.ccd.sdk' version '6.14.0'
+    id 'hmcts.ccd.sdk' version '6.15.0'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.2194'
 }
 


### PR DESCRIPTION
Updates the CCD SDK Gradle plugin to `6.15.0`.

This picks up the CCD data migration event batching improvements from the latest dtsse-ccd-config-generator release.
