### PR TITLE
Bump CCD SDK to 6.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.freefair.lombok' version '8.14.4'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
-    id 'hmcts.ccd.sdk' version '6.15.0'
+    id 'hmcts.ccd.sdk' version '6.17.0'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.2194'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -434,7 +434,7 @@ ext {
     pact_version = '4.3.10'
     reformLoggingVersion = '6.0.1'
     serenity = '5.3.10'
-    tomcatEmbedVersion = '10.1.55'
+    tomcatEmbedVersion = '10.1.56'
     jacksonVersion = '2.22.0'
     jacksonAnnotationsVersion = '2.22'
     jacksonV3Version = '3.2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -70,6 +70,17 @@
         <cve>CVE-2026-39882</cve>
         <cve>CVE-2026-39883</cve>
     </suppress>
+    <!-- CCD SDK 6.17.0 pins Elasticsearch client 9.4.2 through ccd-runtime-indexing Gradle metadata.
+         Suppress until the SDK publishes a patched runtime dependency. -->
+    <suppress>
+        <notes><![CDATA[
+   file name: elasticsearch-java-9.4.2.jar, elasticsearch-rest5-client-9.4.2.jar
+   Transitive dependency from com.github.hmcts:ccd-runtime-indexing:6.17.0.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/co\.elastic\.clients/elasticsearch\-(java|rest5\-client)@9\.4\.2$</packageUrl>
+        <cve>CVE-2026-56148</cve>
+        <cve>CVE-2026-56149</cve>
+    </suppress>
     <!-- All other CVEs below -->
     <!-- CVE-2026-54515 affects jackson-databind 2.22.0 which is the latest available version.
          No fixed version exists. Suppress until a patched release is available. -->


### PR DESCRIPTION
Updates the CCD SDK Gradle plugin to `6.17.0`.


