### PR TITLE
Enable Postgres Query Store

### DIFF
--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -28,6 +28,18 @@ module "postgres" {
     {
       "name" : "backslash_quote",
       "value" : "on"
+    },
+    {
+      name  = "pg_qs.query_capture_mode"
+      value = "top"
+    },
+    {
+      name  = "pg_qs.store_query_plans"
+      value = "on"
+    },
+    {
+      name  = "pgms_wait_sampling.query_capture_mode"
+      value = "all"
     }
   ]
   auto_grow_enabled = true


### PR DESCRIPTION
Enable Query Store for the ET COS flexible Postgres server so slow and resource-intensive queries can be reviewed from the azure_sys database.

This captures top-level query runtime stats, stores query plans, and enables wait sampling.