### PR TITLE
Update CCD SDK to 6.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.freefair.lombok' version '8.14.4'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
-    id 'hmcts.ccd.sdk' version '6.19.0'
+    id 'hmcts.ccd.sdk' version '6.20.0'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.2194'
 }
 


### PR DESCRIPTION
## Summary
- Updates hmcts.ccd.sdk from 6.19.0 to 6.20.0.

## Validation
- ./gradlew help currently fails because 6.20.0 is not yet present in the configured HMCTS Maven feed.
- HMCTS Maven metadata currently lists 6.19.0 as the latest published release.