### PR TITLE
Set prod Postgres storage size

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,7 +99,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
-  env.PUPPETEER_CACHE_DIR = '.puppeteer-cache'
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,6 +99,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
+  env.PUPPETEER_CACHE_DIR = '.puppeteer-cache'
   loadVaultSecrets(secrets)
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()

--- a/build.gradle
+++ b/build.gradle
@@ -252,8 +252,11 @@ tasks.register('functional', Test) {
     maxHeapSize = '1G'
 }
 
+def puppeteerCacheDir = layout.buildDirectory.dir('puppeteer-cache').get().asFile.absolutePath
+
 tasks.register('yarnInstall', Exec) {
     workingDir '.'
+    environment 'PUPPETEER_CACHE_DIR', puppeteerCacheDir
     commandLine 'yarn', 'install'
 }
 

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -18,6 +18,7 @@ module "postgres" {
     }
   ]
   pgsql_version                  = "15"
+  pgsql_storage_mb               = var.env == "prod" ? 131072 : 65536
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
   pgsql_server_configuration = [

--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -18,7 +18,7 @@ module "postgres" {
     }
   ]
   pgsql_version                  = "15"
-  pgsql_storage_mb               = var.env == "prod" ? 131072 : 65536
+  pgsql_storage_mb               = var.env == "prod" ? 262144 : 65536
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
   pgsql_server_configuration = [


### PR DESCRIPTION
Sets the prod PostgreSQL flexible server storage value to the current auto-grown size so Terraform does not try to shrink the server back to the module default. Non-prod environments keep the existing 64GB default.