### PR TITLE
CVE-2026-54291

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -520,7 +520,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql:11.20.3'
     implementation 'org.flywaydb:flyway-core:11.20.3'
     // CVE-2026-42198
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.11'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.12'
     implementation group: 'org.slf4j', name: 'slf4j-ext', version: '2.0.17'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
### Jira link

There is no Jira link.

-----

### Change description

Upgrade of postresql driver to 42.7.12 for CVE-2026-54291 vulnerability.

-----

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
