### PR TITLE
Bump CCD SDK to 6.23.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.freefair.lombok' version '8.14.4'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
-    id 'hmcts.ccd.sdk' version '6.22.0'
+    id 'hmcts.ccd.sdk' version '6.23.0'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.2240'
 }
 


### PR DESCRIPTION
Updates the CCD SDK dependency to 6.23.0, which includes the CCD data migration cutover changes from hmcts/dtsse-ccd-config-generator PR #1021.