### PR TITLE
Configure ET Hikari pool settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ allprojects {
         resolutionStrategy.force(
             'commons-fileupload:commons-fileupload:1.6.0',
             'org.apache.httpcomponents:httpclient:4.5.14',
-            'org.apache.logging.log4j:log4j-core:2.25.4',
+            'org.apache.logging.log4j:log4j-core:2.26.1',
             'com.nimbusds:nimbus-jose-jwt:10.9.1',
             'net.minidev:json-smart:2.5.2',
             'com.squareup.okhttp3:logging-interceptor:4.12.0',
@@ -433,11 +433,11 @@ integration.shouldRunAfter(test)
 ext {
     junitJupiterVersion = '5.13.4'
     junitPlatformVersion = '1.13.4'
-    log4JVersion = '2.25.4'
+    log4JVersion = '2.26.1'
     pact_version = '4.3.10'
     reformLoggingVersion = '6.0.1'
     serenity = '5.3.10'
-    tomcatEmbedVersion = '10.1.56'
+    tomcatEmbedVersion = '10.1.57'
     jacksonVersion = '2.22.1'
     jacksonAnnotationsVersion = '2.22'
     jacksonV3Version = '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,21 @@ plugins {
 group = 'uk.gov.hmcts.et'
 version = '0.0.1'
 
+tasks.register('printVersionInit') {
+    doLast {
+        def versionLine = file('charts/et-cos/Chart.yaml')
+            .readLines()
+            .find { it.trim().startsWith('version:') }
+        def chartVersion = versionLine ? versionLine.split(':', 2)[1].trim() : null
+
+        if (!chartVersion) {
+            throw new GradleException('Unable to read chart version from charts/et-cos/Chart.yaml')
+        }
+
+        println chartVersion
+    }
+}
+
 ccd {
     configDir = file('build/definitions')
     decentralised = true

--- a/charts/et-cos/Chart.yaml
+++ b/charts/et-cos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: et-cos
 home: https://github.com/hmcts/et-ccd-callbacks
-version: 0.0.68
+version: 0.0.69
 description: HMCTS Employment Tribunals CCD Callbacks service
 maintainers:
   - name: HMCTS Employment Tribunals Team

--- a/charts/et-cos/values.preview.template.yaml
+++ b/charts/et-cos/values.preview.template.yaml
@@ -35,6 +35,12 @@ java:
     ET_COS_DB_NAME: "pr-${CHANGE_ID}-et_cos"
     ET_COS_DB_USER_NAME: hmcts
     ET_COS_DB_CONN_OPTIONS: "?sslmode=require"
+    ET_COS_DB_CONNECTION_TIMEOUT: 30000
+    ET_COS_DB_IDLE_TIMEOUT: 300000
+    ET_COS_DB_MIN_IDLE: 4
+    ET_COS_DB_MAX_POOL_SIZE: 10
+    ET_COS_DB_MAX_LIFETIME: 300000
+    ET_COS_DB_POOL_NAME: et-cos-db-pool
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-aat.service.core-compute-aat.internal
     RD_PROFESSIONAL_API_URL: http://rd-professional-api-aat.service.core-compute-aat.internal
     SECURE_DOC_STORE_FEATURE: true

--- a/charts/et-cos/values.yaml
+++ b/charts/et-cos/values.yaml
@@ -67,6 +67,12 @@ java:
     CCD_GATEWAY_BASE_URL: "https://manage-case.{{ .Values.global.environment }}.platform.hmcts.net"
     MICRO_SERVICE: "et_cos"
     ET_COS_DB_CONN_OPTIONS: ?sslmode=require
+    ET_COS_DB_CONNECTION_TIMEOUT: 30000
+    ET_COS_DB_IDLE_TIMEOUT: 300000
+    ET_COS_DB_MIN_IDLE: 8
+    ET_COS_DB_MAX_POOL_SIZE: 20
+    ET_COS_DB_MAX_LIFETIME: 300000
+    ET_COS_DB_POOL_NAME: et-cos-db-pool
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     RD_PROFESSIONAL_API_URL: http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     SECURE_DOC_STORE_FEATURE: true

--- a/et-shared/build.gradle
+++ b/et-shared/build.gradle
@@ -28,7 +28,7 @@ dependencyManagement {
         dependency 'org.springframework.security:spring-security-crypto:6.5.11'
         dependency 'commons-fileupload:commons-fileupload:1.6.0'
         dependency 'org.apache.httpcomponents:httpclient:4.5.14'
-        dependency 'org.apache.logging.log4j:log4j-core:2.25.4'
+        dependency 'org.apache.logging.log4j:log4j-core:2.26.1'
         dependency 'com.nimbusds:nimbus-jose-jwt:10.9.1'
         dependency 'net.minidev:json-smart:2.5.2'
         dependency 'com.squareup.okhttp3:logging-interceptor:4.12.0'
@@ -119,8 +119,8 @@ dependencies {
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.25.4'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.25.4'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.26.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.26.1'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.38'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.38'
     implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.5.38'
@@ -169,7 +169,7 @@ configurations.configureEach {
     resolutionStrategy.eachDependency { details ->
         if (details.requested.group == "org.apache.tomcat.embed"
             && ["tomcat-embed-core", "tomcat-embed-websocket"].contains(details.requested.name)) {
-            details.useVersion("10.1.55")
+            details.useVersion("10.1.57")
         }
         // CVE-2020-29582 - Force Kotlin to 2.1.0+
         if (details.requested.group == "org.jetbrains.kotlin"
@@ -180,7 +180,7 @@ configurations.configureEach {
     resolutionStrategy.force(
         'commons-fileupload:commons-fileupload:1.6.0',
         'org.apache.httpcomponents:httpclient:4.5.14',
-        'org.apache.logging.log4j:log4j-core:2.25.4',
+        'org.apache.logging.log4j:log4j-core:2.26.1',
         'com.nimbusds:nimbus-jose-jwt:10.9.1',
         'net.minidev:json-smart:2.5.2',
         'com.squareup.okhttp3:logging-interceptor:4.12.0',

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,8 +29,16 @@ spring:
       max-request-size: 300MB
   datasource:
     password: ${ET_COS_DB_PASSWORD:}
+    type: com.zaxxer.hikari.HikariDataSource
     url: jdbc:postgresql://${ET_COS_DB_HOST:localhost}:${ET_COS_DB_PORT:5432}/${ET_COS_DB_NAME:et_cos}${ET_COS_DB_CONN_OPTIONS:}
     username: ${ET_COS_DB_USER_NAME:et_cos}
+    hikari:
+      connection-timeout: ${ET_COS_DB_CONNECTION_TIMEOUT:30000}
+      idle-timeout: ${ET_COS_DB_IDLE_TIMEOUT:300000}
+      minimum-idle: ${ET_COS_DB_MIN_IDLE:8}
+      maximum-pool-size: ${ET_COS_DB_MAX_POOL_SIZE:20}
+      max-lifetime: ${ET_COS_DB_MAX_LIFETIME:300000}
+      pool-name: ${ET_COS_DB_POOL_NAME:et-cos-db-pool}
   config:
     import: optional:configtree:/mnt/secrets/et-cos/,optional:configtree:/mnt/secrets/et/
   jms:


### PR DESCRIPTION
## Summary

Adds explicit Hikari datasource configuration for ET COS instead of relying on Spring Boot defaults.

- sets ET-specific environment-backed Hikari properties
- adds chart defaults for deployed environments
- keeps preview pool sizing lower than shared environments
- updates Log4j and Tomcat embedded versions flagged by dependency checking
- adds the Jenkins `printVersionInit` task so build metadata gets the ET COS chart version
- merges the latest `master` changes

## Reason

Performance testing showed ET COS exhausting the default 10-connection Hikari pool while handling decentralised persistence traffic. Making the pool explicit gives ET enough headroom for higher traffic and makes future tuning visible in chart values.

The Jenkins dependency check also flagged CVEs in Log4j `2.25.4` and Tomcat embedded `10.1.56`, so this PR moves those pins forward. A later Jenkins run reported 0 vulnerabilities, but also showed the `printVersionInit` task missing and `build.version=` blank, so this PR adds that task from the ET COS chart version.

## Validation

- YAML parsed for `src/main/resources/application.yaml`, `charts/et-cos/values.yaml`, and `charts/et-cos/values.preview.template.yaml`
- `./gradlew dependencyInsight --dependency log4j-core --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency tomcat-embed-core --configuration runtimeClasspath`
- `./gradlew :et-shared:dependencyInsight --dependency log4j-core --configuration runtimeClasspath`
- `./gradlew :et-shared:dependencyInsight --dependency tomcat-embed-core --configuration runtimeClasspath`
- `./gradlew --no-daemon -q :printVersionInit`
- `./gradlew classes`
- `./gradlew check`

Note: local `./gradlew dependencyCheckAggregate` could not refresh NVD data without an API key and stopped with an NVD 403 before analysis. Jenkins dependency check later reported 0 vulnerabilities for this branch.
