### PR TITLE
feat: enable database reporting privileges for production environment

### DIFF
--- a/infrastructure/database-flexi.tf
+++ b/infrastructure/database-flexi.tf
@@ -21,6 +21,7 @@ module "postgres" {
   pgsql_storage_mb               = var.env == "prod" ? 262144 : 65536
   admin_user_object_id           = var.jenkins_AAD_objectId
   force_user_permissions_trigger = "2"
+  enable_db_report_privileges    = true
   pgsql_server_configuration = [
     {
       name  = "azure.extensions"


### PR DESCRIPTION
Enable DB reporting so that when dencentralised in prod, https://github.com/hmcts/postgresql-cron-jobs can run automated reporting queries against the DB

https://github.com/hmcts/terraform-module-postgresql-flexible#input_enable_db_report_privileges