### PR TITLE
Reduce preview database pool sizes

### DIFF
--- a/charts/et-cos/values.preview.template.yaml
+++ b/charts/et-cos/values.preview.template.yaml
@@ -37,8 +37,9 @@ java:
     ET_COS_DB_CONN_OPTIONS: "?sslmode=require"
     ET_COS_DB_CONNECTION_TIMEOUT: 30000
     ET_COS_DB_IDLE_TIMEOUT: 300000
-    ET_COS_DB_MIN_IDLE: 4
-    ET_COS_DB_MAX_POOL_SIZE: 10
+    # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+    ET_COS_DB_MIN_IDLE: 1
+    ET_COS_DB_MAX_POOL_SIZE: 2
     ET_COS_DB_MAX_LIFETIME: 300000
     ET_COS_DB_POOL_NAME: et-cos-db-pool
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-aat.service.core-compute-aat.internal
@@ -246,6 +247,8 @@ ccd:
       devmemoryLimits: 1536Mi
       environment:
         USER_PROFILE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_definition,ccd_admin
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        USER_PROFILE_DB_MAX_POOL_SIZE: 2
       ingressHost: ccd-user-profile-api-${SERVICE_FQDN}
 
   ccd-data-store-api:
@@ -276,6 +279,9 @@ ccd:
         DEFINITION_STORE_HOST: https://ccd-definition-store-${SERVICE_FQDN}
         USER_PROFILE_HOST: https://ccd-user-profile-api-${SERVICE_FQDN}
         ROLE_ASSIGNMENT_URL: https://am-role-assignment-${SERVICE_FQDN}
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        DATA_STORE_DB_MAX_POOL_SIZE: 2
+        DATA_STORE_DB_MIN_IDLE: 1
         SPRING_APPLICATION_JSON: |
           {
             "ccd": {
@@ -309,6 +315,8 @@ ccd:
         CCD_DATA_STORE_URL: http://{{ .Release.Name }}-ccd-data-store-api
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,et_cos
         RUN_LD_ON_STARTUP: false
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        MAX_POOL_SIZE: 2
       keyVaults:
         am:
           secrets:
@@ -344,6 +352,8 @@ ccd:
         ELASTIC_SEARCH_HOST: ${SERVICE_NAME}-es-master
         #TS_TRANSLATION_SERVICE_HOST: http://ts-translation-service-aat.service.core-compute-aat.internal
         WELSH_TRANSLATION_ENABLED: false
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        DEFINITION_STORE_DB_MAX_POOL_SIZE: 2
       ingressHost: ccd-definition-store-${SERVICE_FQDN}
 
   ccd-admin-web:
@@ -795,6 +805,9 @@ wa:
       devmemoryLimits: 1536Mi
       environment:
         CAMUNDA_DB_CONN_OPTIONS: "?stringtype=unspecified&reWriteBatchedInserts=true&sslmode=require"
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 2
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 1
 
   wa-task-management-api:
     java:
@@ -811,6 +824,11 @@ wa:
         ROLE_ASSIGNMENT_URL: https://am-role-assignment-${SERVICE_FQDN}
         ALLOWED_JURISDICTIONS: employment
         ALLOWED_CASE_TYPES: et_englandwales,et_englandwales_listings,et_englandwales_multiple,et_scotland,et_scotland_listings,et_scotland_multiple,et_admin
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        SPRING_DATASOURCE_MAXIMUM_POOL_SIZE: 2
+        SPRING_DATASOURCE_MINIMUM_IDLE: 1
+        SPRING_DATASOURCE_REPLICA_MAXIMUM_POOL_SIZE: 2
+        SPRING_DATASOURCE_REPLICA_MINIMUM_IDLE: 1
 
   wa-case-event-handler:
     java:
@@ -834,6 +852,9 @@ wa:
         AZURE_SERVICE_BUS_TOPIC_NAME: ${SERVICE_NAME}-ccd-case-events
         AZURE_SERVICE_BUS_SUBSCRIPTION_NAME: ${SERVICE_NAME}-ccd-case-events
         AZURE_SERVICE_BUS_CCD_CASE_EVENTS_SUBSCRIPTION_NAME: ${SERVICE_NAME}-ccd-case-events
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 2
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 1
   wa-task-monitor:
     java:
       ingressHost: wa-task-monitor-${SERVICE_FQDN}
@@ -851,6 +872,9 @@ wa:
       devmemoryLimits: 1536Mi
       environment:
         DB_READER_USERNAME: hmcts
+        # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 2
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 1
   wa:
     postgresql:
       enabled: false
@@ -892,6 +916,9 @@ ccd-message-publisher:
       DATA_STORE_DB_USERNAME: hmcts
       DATA_STORE_DB_OPTIONS: "?currentSchema=ccd&stringtype=unspecified&reWriteBatchedInserts=true&sslmode=require"
       CCD_CASE_EVENTS_DESTINATION: ${SERVICE_NAME}-ccd-case-events
+      # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+      MESSAGE_PUBLISHER_DB_MAX_POOL_SIZE: 2
+      MESSAGE_PUBLISHER_DB_MIN_IDLE: 1
     secrets:
       SERVICE_BUS_CONNECTION_STRING:
         secretRef: et-sb-preview
@@ -976,6 +1003,9 @@ am-org-role-mapping-service:
       TESTING_SUPPORT_ENABLED: true
       JUDICIAL_REF_APP_V2_ACTIVE: true
       JUDICIAL_REF_APP_V2_FILTER_AUTHS_BY_APP_ID: true
+      # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+      SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 2
+      SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 1
 
 rd-caseworker-ref-api:
   enabled: true
@@ -1021,6 +1051,8 @@ rd-caseworker-ref-api:
       LAUNCH_DARKLY_ENV: "preview"
       ENVIRONMENT_NAME: "preview"
       EMAIL_DOMAIN_LIST: "justice.gov.uk,dwp.gov.uk,hmrc.gov.uk,hmcts.net,dfcni.gov.uk"
+      # Keep preview DB pools small: all ET PRs share et-preview Postgres, which has a limited connection budget.
+      HIKARI_MAX_POOL_SIZE: 2
 
 rd-professional-api:
   enabled: false


### PR DESCRIPTION
## Summary
- Reduce preview-only database pool sizes for ET and dependent services that connect to the shared et-preview Postgres server.
- Cap the verified service-specific pools at 2 connections and keep minimum idle values low where supported.
- Add comments explaining that this protects the shared preview Postgres connection budget used by all ET PRs.

## Why
ET preview PR environments all share the same et-preview Postgres server, which has a limited connection budget. Each PR deploys multiple database-backed dependency services, so default Hikari pool sizes can consume a large share of the shared connection limit.

## Verification
- ruby -e "require 'yaml'; YAML.load_file('charts/et-cos/values.preview.template.yaml'); puts 'yaml ok'"
- git diff --check
