### PR TITLE
Limit Renovate updates to morning window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,7 @@
   "ignoreDeps": [
     "aac-manage-case-assignment"
   ],
+  "schedule": ["after 7am and before 9am every weekday"],
+  "updateNotScheduled": false,
   "automergeSchedule": ["before 12pm every weekday"]
 }


### PR DESCRIPTION
Limits Renovate branch creation and updates, including automatic rebases, to 7am–9am on weekdays.

Disabling out-of-schedule updates prevents Renovate from force-pushing every open dependency PR after `master` changes later in the day. GitHub platform automerge behaviour is unchanged.
