### PR TITLE
Update suppressions.xml with new CVE entries

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -125,4 +125,16 @@
         <cve>CVE-2026-54514</cve>
         <cve>CVE-2026-54515</cve>
     </suppress>
+       <!-- Netty 4.2.16.Final is the latest available version; no fix released for these CVEs.
+         Suppress until a patched release is available. -->
+    <suppress>
+        <notes><![CDATA[
+   file name: netty-*-4.2.16.Final.jar
+   Latest available version. No fix released for CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 as of 2026-07-23.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@4\.2\.16\.Final$</packageUrl>
+        <cve>CVE-2026-44891</cve>
+        <cve>CVE-2026-55831</cve>
+        <cve>CVE-2026-55833</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Suppresses three CVEs flagged against all `io.netty` 4.2.16.Final artifacts in the OWASP dependency check pipeline:

- `CVE-2026-44891`
- `CVE-2026-55831`
- `CVE-2026-55833`

4.2.16.Final is the latest available Netty release and no patched version exists at the time of this change.

A single suppression entry using a package-URL regex (`^pkg:maven/io\.netty/netty\-.*@4\.2\.16\.Final$`) covers all 25 affected jars.

## Checklist
- [x] Suppression scoped to the specific version (`4.2.16.Final`) so it will no longer apply once a patched version is adopted
- [x] Notes in the suppression file document the reason and date