### PR TITLE
fix: update continuingRespondent method

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/service/CaseManagementForCaseWorkerService.java
@@ -459,24 +459,25 @@ public class CaseManagementForCaseWorkerService {
 
     public CaseData continuingRespondent(CCDRequest ccdRequest) {
         CaseData caseData = ccdRequest.getCaseDetails().getCaseData();
-        if (isEmpty(caseData.getRepCollection())) {
-            List<RespondentSumTypeItem> continuingRespondent = new ArrayList<>();
-            List<RespondentSumTypeItem> notContinuingRespondent = new ArrayList<>();
-            for (RespondentSumTypeItem respondentSumTypeItem : caseData.getRespondentCollection()) {
-                RespondentSumType respondentSumType = respondentSumTypeItem.getValue();
-                if (YES.equals(respondentSumType.getResponseContinue())) {
-                    continuingRespondent.add(respondentSumTypeItem);
-                } else if (NO.equals(respondentSumType.getResponseContinue())) {
-                    notContinuingRespondent.add(respondentSumTypeItem);
-                } else {
-                    respondentSumType.setResponseContinue(YES);
-                    continuingRespondent.add(respondentSumTypeItem);
-                }
-            }
-            caseData.setRespondentCollection(Stream.concat(continuingRespondent.stream(),
-                    notContinuingRespondent.stream()).toList());
-            respondentDefaults(caseData);
+        if (isEmpty(caseData.getRespondentCollection())) {
+            return caseData;
         }
+        List<RespondentSumTypeItem> continuingRespondent = new ArrayList<>();
+        List<RespondentSumTypeItem> notContinuingRespondent = new ArrayList<>();
+        caseData.getRespondentCollection().forEach(respondentSumTypeItem -> {
+            RespondentSumType respondentSumType = respondentSumTypeItem.getValue();
+            if (YES.equals(respondentSumType.getResponseContinue())) {
+                continuingRespondent.add(respondentSumTypeItem);
+            } else if (NO.equals(respondentSumType.getResponseContinue())) {
+                notContinuingRespondent.add(respondentSumTypeItem);
+            } else {
+                respondentSumType.setResponseContinue(YES);
+                continuingRespondent.add(respondentSumTypeItem);
+            }
+        });
+        caseData.setRespondentCollection(Stream.concat(continuingRespondent.stream(),
+                notContinuingRespondent.stream()).toList());
+        respondentDefaults(caseData);
         return caseData;
     }
 


### PR DESCRIPTION
As part of https://github.com/hmcts/ethos-repl-docmosis-service/pull/1391, logic was added to order respondents by whether they are continuing or not. In one of the [commits](https://github.com/hmcts/ethos-repl-docmosis-service/pull/1391/changes/5c43e77a4c2f5373cbe1c186e94faf36ad0faa02), the respondentCollection accidentally got changed to the repCollection which meant the the logic has not been working properly.