### PR TITLE
Avoid reinstalling Playwright system dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "hmcts",
   "private": true,
   "scripts": {
-    "pwinstall": "yarn playwright install --with-deps",
+    "pwinstall": "yarn playwright install",
     "test:smoke": "yarn pwinstall chromium && yarn playwright test -c src/test/e2e/playwright.config.ts  --project=chromium --grep @smoke",
     "test:functional-chromium": "yarn pwinstall chromium && yarn test:functional-ccd-callback",
     "test:full-functional-chromium": "yarn pwinstall chromium && yarn playwright test -c src/test/e2e/playwright.config.ts --project=chromium --grep-invert @accessibility",


### PR DESCRIPTION
## What changed

Use `playwright install` instead of `playwright install --with-deps` before the ET Playwright suites.

## Why

The Jenkins Ubuntu image already installs the Playwright Linux system dependencies during image provisioning. Running `--with-deps` again in each build invokes `apt` on the live worker and can fail when `unattended-upgrades` holds the dpkg lock.

This still downloads the requested Playwright browser, but avoids modifying OS packages during the test job.

## Validation

- Parsed `package.json` successfully
- `git diff --check`

The PR is draft so its Jenkins smoke build can confirm the preinstalled worker dependencies are sufficient.