### PR TITLE
RET-6665 bug fixes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
@@ -60,17 +60,17 @@ public class ManageCaseController {
      * @return the requested case wrapped in a {@link CaseDetails} object
      */
     @PostMapping("/user-case")
-    @Operation(summary = "Return individual case details")
+    @Operation(summary = "Return individual case details, filtered by case role (defaults to CREATOR). A request "
+        + "for CREATOR also matches the user's CLAIMANTNONLEGALREPRESENTATIVE case. The matched role is carried "
+        + "under 'caseUserRole' in the case data.")
     @ApiResponseGroup
     public ResponseEntity<CaseDetails> getUserCaseDetails(
         @RequestHeader(AUTHORIZATION) String authorization,
         @RequestParam(value = CASE_USER_ROLE_API_PARAMETER_NAME, required = false) String caseUserRole,
         @RequestBody CaseRequest caseRequest) {
-        CaseDetails caseDetails = manageCaseRoleService.getUserCaseByCaseUserRole(
+        CaseDetails caseDetails = manageCaseRoleService.getUserCaseByCaseUserRoles(
             authorization, caseRequest.getCaseId(),
-            StringUtils.isBlank(caseUserRole)
-                ? CASE_USER_ROLE_CREATOR
-                : STRING_LEFT_SQUARE_BRACKET + caseUserRole.trim() + STRING_RIGHT_SQUARE_BRACKET);
+            ManageCaseRoleServiceUtil.getCaseUserRoles(caseUserRole));
         return ok(caseDetails);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,9 +33,6 @@ import java.util.List;
 import static org.springframework.http.ResponseEntity.ok;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.AUTHORIZATION;
 import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_API_PARAMETER_NAME;
-import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_CREATOR;
-import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.STRING_LEFT_SQUARE_BRACKET;
-import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.STRING_RIGHT_SQUARE_BRACKET;
 
 /**
  * Rest Controller will use {@link CaseService} for interacting and accessing cases.
@@ -178,9 +174,7 @@ public class ManageCaseController {
         return ok(hubLinkService.updateHubLinkStatuses(
             request,
             authorization,
-            StringUtils.isBlank(caseUserRole)
-                ? CASE_USER_ROLE_CREATOR
-                : STRING_LEFT_SQUARE_BRACKET + caseUserRole.trim() + STRING_RIGHT_SQUARE_BRACKET));
+            ManageCaseRoleServiceUtil.getCaseUserRoles(caseUserRole)));
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/HubLinkService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/HubLinkService.java
@@ -12,6 +12,8 @@ import uk.gov.hmcts.reform.et.syaapi.helper.EmployeeObjectMapper;
 import uk.gov.hmcts.reform.et.syaapi.models.HubLinksStatusesRequest;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -30,7 +32,7 @@ public class HubLinkService {
      */
     public CaseDetails updateHubLinkStatuses(HubLinksStatusesRequest request,
                                              String authorization,
-                                             String caseUserRole) {
+                                             List<String> caseUserRoles) {
 
         if (featureToggleService.isCaseFlagsEnabled()) {
             log.info("Case flags enabled - calling UPDATE_HUBLINK_STATUS");
@@ -53,10 +55,11 @@ public class HubLinkService {
             );
         } else {
             log.info("Case flags disabled - calling UPDATE_CASE_SUBMITTED");
-            // Added parameter case user role as creator.
-            CaseDetails caseDetails = manageCaseRoleService.getUserCaseByCaseUserRole(authorization,
+            // Match the case by any of the requested roles (a request for [CREATOR] also matches a
+            // self-representing claimant's [CLAIMANTNONLEGALREPRESENTATIVE] case).
+            CaseDetails caseDetails = manageCaseRoleService.getUserCaseByCaseUserRoles(authorization,
                                                                             request.getCaseId(),
-                                                                            caseUserRole);
+                                                                            caseUserRoles);
             caseDetails.getData().put("hubLinksStatuses", request.getHubLinksStatuses());
 
             return caseService.triggerEvent(

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/ManageCaseRoleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/ManageCaseRoleService.java
@@ -735,6 +735,33 @@ public class ManageCaseRoleService {
     }
 
     /**
+     * With the given caseId, gets the case details if the user holds any of the given case roles, filtering the
+     * case documents by the matched role and stamping that role into the case data (under {@code caseUserRole}).
+     * Mirrors {@link #getUserCasesByCaseUserRoles} for the single-case endpoint, so a request for {@code [CREATOR]}
+     * also matches a self-representing claimant's {@code [CLAIMANTNONLEGALREPRESENTATIVE]} case.
+     *
+     * @param authorization is used to get the {@link UserInfo} for the request
+     * @param caseId        the id of the case to retrieve
+     * @param caseUserRoles the roles to match
+     * @return the associated {@link CaseDetails} if the user holds one of the roles on it, otherwise {@code null}
+     */
+    @Retryable
+    public CaseDetails getUserCaseByCaseUserRoles(String authorization,
+                                                  String caseId,
+                                                  List<String> caseUserRoles) {
+        CaseDetails caseDetails = ccdApi.getCase(authorization, authTokenGenerator.generate(), caseId);
+        if (ObjectUtils.isEmpty(caseDetails)) {
+            throw new ManageCaseRoleException(
+                new Exception("Unable to find user case by case id: " + caseId));
+        }
+        List<CaseDetails> caseDetailsListByCaseUserRoles =
+            getCasesByCaseDetailsListAuthorizationAndCaseUserRoles(List.of(caseDetails), authorization, caseUserRoles);
+        return CollectionUtils.isNotEmpty(caseDetailsListByCaseUserRoles)
+            ? caseDetailsListByCaseUserRoles.getFirst()
+            : null;
+    }
+
+    /**
      * Given a user derived from the authorisation token in the request,
      * gets all cases {@link CaseDetails} for that user and filters case documents.
      *

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
@@ -358,7 +358,9 @@ class ManageCaseControllerTest {
         ));
         when(hubLinkService.updateHubLinkStatuses(hubLinksStatusesRequest,
                                                   TEST_SERVICE_AUTH_TOKEN,
-                                                  CASE_USER_ROLE_CREATOR)).thenReturn(expectedDetails);
+                                                  List.of(CASE_USER_ROLE_CREATOR,
+                                                          CASE_USER_ROLE_CLAIMANT_NON_LEGAL_REPRESENTATIVE)))
+            .thenReturn(expectedDetails);
 
         mockMvc.perform(
             put("/cases/update-hub-links-statuses", CASE_ID)
@@ -369,7 +371,7 @@ class ManageCaseControllerTest {
         verify(hubLinkService, times(1)).updateHubLinkStatuses(
             hubLinksStatusesRequest,
             TEST_SERVICE_AUTH_TOKEN,
-            CASE_USER_ROLE_CREATOR
+            List.of(CASE_USER_ROLE_CREATOR, CASE_USER_ROLE_CLAIMANT_NON_LEGAL_REPRESENTATIVE)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -115,9 +116,10 @@ class ManageCaseControllerTest {
 
         // given
         when(verifyTokenService.verifyTokenSignature(any())).thenReturn(true);
-        when(manageCaseRoleService.getUserCaseByCaseUserRole(TEST_SERVICE_AUTH_TOKEN,
-                                                             caseRequest.getCaseId(),
-                                                             CASE_USER_ROLE_CREATOR))
+        when(manageCaseRoleService.getUserCaseByCaseUserRoles(
+                 TEST_SERVICE_AUTH_TOKEN,
+                 caseRequest.getCaseId(),
+                 List.of(CASE_USER_ROLE_CREATOR, CASE_USER_ROLE_CLAIMANT_NON_LEGAL_REPRESENTATIVE)))
             .thenReturn(expectedDetails);
         // when
         mockMvc.perform(post("/cases/user-case", CASE_ID)
@@ -212,7 +214,7 @@ class ManageCaseControllerTest {
         Request request = Request.create(
             Request.HttpMethod.GET, "/test", Collections.emptyMap(), null, new RequestTemplate());
         when(verifyTokenService.verifyTokenSignature(anyString())).thenReturn(true);
-        when(manageCaseRoleService.getUserCaseByCaseUserRole(anyString(), anyString(), anyString())).thenThrow(
+        when(manageCaseRoleService.getUserCaseByCaseUserRoles(anyString(), anyString(), anyList())).thenThrow(
             new FeignException.BadRequest(
                 "Bad request",
                 request,

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/HubLinkServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/HubLinkServiceTest.java
@@ -10,6 +10,8 @@ import uk.gov.hmcts.reform.et.syaapi.helper.CaseDetailsConverter;
 import uk.gov.hmcts.reform.et.syaapi.model.TestData;
 import uk.gov.hmcts.reform.et.syaapi.models.HubLinksStatusesRequest;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -80,7 +82,7 @@ class HubLinkServiceTest {
 
         hubLinkService.updateHubLinkStatuses(hubLinksStatusesRequest,
                                              TEST_SERVICE_AUTH_TOKEN,
-                                             CASE_USER_ROLE_CREATOR);
+                                             List.of(CASE_USER_ROLE_CREATOR));
 
         verify(caseDetailsConverter, times(1)).caseDataContent(
             any(),
@@ -98,15 +100,17 @@ class HubLinkServiceTest {
             null
         )).thenReturn(testData.getCaseDetailsWithData());
         when(featureToggleService.isCaseFlagsEnabled()).thenReturn(false);
-        when(manageCaseRoleService.getUserCaseByCaseUserRole(TEST_SERVICE_AUTH_TOKEN, CASE_ID, CASE_USER_ROLE_CREATOR))
+        when(manageCaseRoleService.getUserCaseByCaseUserRoles(
+            TEST_SERVICE_AUTH_TOKEN, CASE_ID, List.of(CASE_USER_ROLE_CREATOR)))
             .thenReturn(testData.getCaseDetailsWithData());
 
-        hubLinkService.updateHubLinkStatuses(hubLinksStatusesRequest, TEST_SERVICE_AUTH_TOKEN, CASE_USER_ROLE_CREATOR);
+        hubLinkService.updateHubLinkStatuses(hubLinksStatusesRequest, TEST_SERVICE_AUTH_TOKEN,
+                                             List.of(CASE_USER_ROLE_CREATOR));
 
-        verify(manageCaseRoleService, times(1)).getUserCaseByCaseUserRole(
+        verify(manageCaseRoleService, times(1)).getUserCaseByCaseUserRoles(
             TEST_SERVICE_AUTH_TOKEN,
             hubLinksStatusesRequest.getCaseId(),
-            CASE_USER_ROLE_CREATOR
+            List.of(CASE_USER_ROLE_CREATOR)
         );
         verify(caseService, times(1)).triggerEvent(
             TEST_SERVICE_AUTH_TOKEN, hubLinksStatusesRequest.getCaseId(),

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/ManageCaseRoleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/ManageCaseRoleServiceTest.java
@@ -74,8 +74,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
 import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_CCD_API_POST_METHOD_NAME;
+import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_CLAIMANT_NON_LEGAL_REPRESENTATIVE;
 import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_CLAIMANT_SOLICITOR;
 import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_CREATOR;
+import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_DATA_KEY;
 import static uk.gov.hmcts.reform.et.syaapi.constants.ManageCaseRoleConstants.CASE_USER_ROLE_DEFENDANT;
 import static uk.gov.hmcts.reform.et.syaapi.enums.CaseEvent.REMOVE_OWN_REP_AS_CLAIMANT;
 import static uk.gov.hmcts.reform.et.syaapi.enums.CaseEvent.REMOVE_OWN_REP_AS_RESPONDENT;
@@ -786,6 +788,42 @@ class ManageCaseRoleServiceTest {
                                                                                   caseRequest.getCaseId(),
                                                                                   CASE_USER_ROLE_CREATOR);
         assertEquals(caseTestData.getExpectedDetails(), caseDetails);
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldGetUserCaseWhenHoldingAnyOfTheRequestedRoles() {
+        ReflectionTestUtils.setField(manageCaseRoleService,
+                                     CCD_API_URL_PARAMETER_NAME,
+                                     CCD_API_URL_PARAMETER_TEST_VALUE);
+        when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
+        when(idamClient.getUserInfo(ArgumentMatchers.anyString())).thenReturn(userInfo);
+        when(ccdApi.getCase(
+            TEST_SERVICE_AUTH_TOKEN,
+            TEST_SERVICE_AUTH_TOKEN,
+            caseTestData.getCaseRequest().getCaseId()
+        )).thenReturn(caseTestData.getExpectedDetails());
+        CaseRequest caseRequest = CaseRequest.builder()
+            .caseId(caseTestData.getCaseRequest().getCaseId()).build();
+        CaseAssignmentUserRole caseAssignedUserRole = CaseAssignmentUserRole.builder()
+            .caseDataId(caseRequest.getCaseId())
+            .caseRole(CASE_USER_ROLE_CREATOR)
+            .userId(USER_ID).build();
+        CaseAssignedUserRolesResponse caseAssignedUserRolesResponse = CaseAssignedUserRolesResponse.builder()
+            .caseAssignedUserRoles(List.of(caseAssignedUserRole))
+            .build();
+        when(restTemplate.postForObject(
+            eq(CCD_API_URL_PARAMETER_TEST_VALUE
+                   + CASE_USER_ROLE_CCD_API_POST_METHOD_NAME),
+            any(HttpEntity.class),
+            eq(CaseAssignedUserRolesResponse.class)))
+            .thenReturn(caseAssignedUserRolesResponse);
+        CaseDetails caseDetails = manageCaseRoleService.getUserCaseByCaseUserRoles(
+            TEST_SERVICE_AUTH_TOKEN,
+            caseRequest.getCaseId(),
+            List.of(CASE_USER_ROLE_CREATOR, CASE_USER_ROLE_CLAIMANT_NON_LEGAL_REPRESENTATIVE));
+        assertThat(caseDetails).isNotNull();
+        assertThat(caseDetails.getData()).containsEntry(CASE_USER_ROLE_DATA_KEY, CASE_USER_ROLE_CREATOR);
     }
 
     @Test


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/RET-6665

### Change description

API Changes — case_user_role now covers self-representing claimants

Endpoints that accept the case_user_role parameter now treat a request for CREATOR (including the default when the parameter is omitted) as also covering the caller's CLAIMANTNONLEGALREPRESENTATIVE cases. This is because a self-representing claimant holds [CLAIMANTNONLEGALREPRESENTATIVE] in place of [CREATOR], so previously these callers got empty/null results (or an error) on these endpoints.

1. POST /cases/user-case                                                                                                                                                                                                                                                                          
  - Returns a single case if the user holds the requested role on it.                                                                                                                                                                                                                               
  - A request for CREATOR (or default) now also matches a [CLAIMANTNONLEGALREPRESENTATIVE] case.                                                                                                                                                                                                    
  - The matched role is stamped into case data under caseUserRole.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                    
 2. PUT /cases/update-hub-links-statuses                                                                                                                                                                                                                                                           
  - Updates hub link statuses for the user's case.                                                                                                                                                                                                                                                  
  - In the case-flags-disabled path it locates the case by role; a request for CREATOR (or default) now also matches a [CLAIMANTNONLEGALREPRESENTATIVE] case, so self-representing claimants can update their hub links instead of hitting a failure.   

Compatibility                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                    
  - Backward compatible. No request/response schema changes; response types are unchanged (List<CaseDetails> / CaseDetails). Existing single-role requests behave as before.                                                                                                                        
  - New field: returned cases from /user-cases and /user-case include an additional caseUserRole entry inside the case data map. Additive — existing consumers are unaffected.                                                                                                                      
  - No change to the request parameter name, format, or the endpoints' HTTP methods/paths.        

### Testing done

Automated (unit tests):                                                                                                                                                                                                                                                                           
  - ManageCaseControllerTest — verified all three endpoints derive the expanded role list:                                                                                                                                                                                                          
    - /user-cases default and ?case_user_role=CREATOR → service called with [CREATOR, CLAIMANTNONLEGALREPRESENTATIVE]; ?case_user_role=DEFENDANT → [DEFENDANT] only.                                                                                                                                
    - /user-case default → single-case lookup with [CREATOR, CLAIMANTNONLEGALREPRESENTATIVE].                                                                                                                                                                                                       
    - /update-hub-links-statuses → HubLinkService invoked with [CREATOR, CLAIMANTNONLEGALREPRESENTATIVE].                                                                                                                                                                                           
  - ManageCaseRoleServiceUtilTest — getCaseUserRoles expands CREATOR/blank → [CREATOR, CLAIMANTNONLEGALREPRESENTATIVE], non-creator roles pass through unchanged; getCaseDetailsByCaseUserRoles returns matches, injects caseUserRole into case data, and excludes unrequested roles.               
  - ManageCaseRoleServiceTest — getUserCasesByCaseUserRoles and getUserCaseByCaseUserRoles return the correct cases with the matched role stamped into data.caseUserRole.                                                                                                                           
  - HubLinkServiceTest — both branches (case flags enabled/disabled) pass the role list through; the disabled branch resolves the case via getUserCaseByCaseUserRoles.                                                                                                                              
  - DocumentUtilTest — parameterized over CREATOR, DEFENDANT, and CLAIMANTNONLEGALREPRESENTATIVE; confirms the non-legal-rep now gets the claimant hidden-document filtering (would have failed before the fix).    


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
