### PR TITLE
Limit expired BF task creation to August 2026 cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/expiredbftask/WaTaskCreationCronForExpiredBfActions.java
+++ b/src/main/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/expiredbftask/WaTaskCreationCronForExpiredBfActions.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.ethos.replacement.docmosis.service.FeatureToggleService;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -45,6 +46,7 @@ public class WaTaskCreationCronForExpiredBfActions implements Runnable {
     private int maxCasesToProcess;
 
     private static final int MAX_VALID_CASE_TO_UPDATE = 300;
+    private static final LocalDate FIRST_ELIGIBLE_BF_DATE = LocalDate.of(2026, Month.AUGUST, 1);
 
     /**
      * This cron job runs every day at 00:01 to create WA tasks for expired BF actions.
@@ -114,8 +116,9 @@ public class WaTaskCreationCronForExpiredBfActions implements Runnable {
                 .filter(bfAction -> bfAction != null && bfAction.getValue() != null)
                 .map(BFActionTypeItem::getValue)
                 .anyMatch(bfActionValue -> !isNullOrEmpty(bfActionValue.getBfDate())
+                        && !LocalDate.parse(bfActionValue.getBfDate()).isBefore(FIRST_ELIGIBLE_BF_DATE)
                         && BFHelper.isBfExpired(bfActionValue, BFHelper.getEffectiveYesterday(
-                                LocalDate.now().minusDays(90)))
+                                FIRST_ELIGIBLE_BF_DATE))
                         && isNullOrEmpty(bfActionValue.getIsWaTaskCreated()));
     }
 
@@ -144,7 +147,7 @@ public class WaTaskCreationCronForExpiredBfActions implements Runnable {
                 .initialSearch(true)
                 .size(maxCasesPerSearch)
                 .build()
-                .getQuery(BFHelper.getEffectiveYesterday(LocalDate.now().minusDays(90)));
+                .getQuery(FIRST_ELIGIBLE_BF_DATE.toString());
 
         List<SubmitEvent> searchResults = ccdClient.buildAndGetElasticSearchRequest(adminUserToken, caseTypeId, query);
         if (CollectionUtils.isEmpty(searchResults)) {
@@ -167,7 +170,7 @@ public class WaTaskCreationCronForExpiredBfActions implements Runnable {
                     .size(maxCasesPerSearch)
                     .searchAfterValue(searchAfterValue)
                     .build()
-                    .getQuery(BFHelper.getEffectiveYesterday(LocalDate.now().minusDays(90)));
+                    .getQuery(FIRST_ELIGIBLE_BF_DATE.toString());
 
             List<SubmitEvent> nextResults = ccdClient.buildAndGetElasticSearchRequest(
                     adminUserToken, caseTypeId, query);

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/WaTaskCreationCronForExpiredBfActionsTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/WaTaskCreationCronForExpiredBfActionsTest.java
@@ -25,8 +25,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -90,6 +92,42 @@ class WaTaskCreationCronForExpiredBfActionsTest {
         verify(ccdClient, times(0))
                 .submitEventForCase(any(), any(), any(), any(), any(), any());
     }
+    @Test
+    void skipsCasesWithBfDateBeforeAugust2026() throws IOException {
+        when(featureToggleService.isWaTaskForExpiredBfActionsEnabled()).thenReturn(true);
+        SubmitEvent submitEvent = expiredBfActionSubmitEvent(LocalDate.of(2026, 7, 31));
+        when(ccdClient.buildAndGetElasticSearchRequest(any(), eq(ENGLANDWALES_CASE_TYPE_ID), any()))
+                .thenReturn(List.of(submitEvent)).thenReturn(Collections.emptyList());
+
+        waTaskCreationCronForExpiredBfActions.run();
+
+        verify(ccdClient, times(0)).startEventForCase(any(), any(), any(), any(), any());
+        verify(ccdClient, times(0)).submitEventForCase(
+                any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void processesCasesWithBfDateFromFirstAugust2026AndUsesCutoffInSearch() throws IOException {
+        when(featureToggleService.isWaTaskForExpiredBfActionsEnabled()).thenReturn(true);
+        SubmitEvent submitEvent = expiredBfActionSubmitEvent(LocalDate.of(2026, 8, 1));
+        when(ccdClient.buildAndGetElasticSearchRequest(any(), eq(ENGLANDWALES_CASE_TYPE_ID), any()))
+                .thenReturn(List.of(submitEvent)).thenReturn(Collections.emptyList());
+
+        CCDRequest build = CCDRequestBuilder.builder().withCaseData(submitEvent.getCaseData()).build();
+        build.getCaseDetails().setJurisdiction("EMPLOYMENT");
+        when(ccdClient.startEventForCase(any(), any(), any(), any(), any())).thenReturn(build);
+
+        waTaskCreationCronForExpiredBfActions.run();
+
+        verify(ccdClient, times(2)).buildAndGetElasticSearchRequest(
+                any(), eq(ENGLANDWALES_CASE_TYPE_ID), argThat(query -> {
+                    assertThat(query).contains("\"from\": \"2026-08-01\"");
+                    return true;
+                }));
+        verify(ccdClient, times(1)).startEventForCase(any(), any(), any(), any(), any());
+        verify(ccdClient, times(1)).submitEventForCase(
+                any(), any(), any(), any(), any(), any());
+    }
 
     @Test
     void processesCasesSuccessfully() throws IOException, URISyntaxException {
@@ -99,7 +137,7 @@ class WaTaskCreationCronForExpiredBfActionsTest {
         SubmitEvent submitEvent = new ObjectMapper().readValue(resource, SubmitEvent.class);
         submitEvent.setCaseId(Long.parseLong("1741710954147332"));
         submitEvent.getCaseData().getBfActions().get(1).getValue().setBfDate(
-                LocalDate.now().minusDays(30).toString());
+                LocalDate.now().minusDays(1).toString());
         when(ccdClient.buildAndGetElasticSearchRequest(any(), eq(ENGLANDWALES_CASE_TYPE_ID), any()))
                 .thenReturn(List.of(submitEvent)).thenReturn(Collections.emptyList());
 
@@ -231,5 +269,21 @@ class WaTaskCreationCronForExpiredBfActionsTest {
         verify(ccdClient, times(1)).startEventForCase(any(), any(), any(), any(), any());
         verify(ccdClient, times(0))
                 .submitEventForCase(any(), any(), any(), any(), any(), any());
+    }
+
+    private SubmitEvent expiredBfActionSubmitEvent(LocalDate bfDate) {
+        BFActionType bfActionType = new BFActionType();
+        bfActionType.setBfDate(bfDate.toString());
+        BFActionTypeItem bfActionTypeItem = new BFActionTypeItem();
+        bfActionTypeItem.setId("TestId");
+        bfActionTypeItem.setValue(bfActionType);
+
+        CaseData caseData = new CaseData();
+        caseData.setBfActions(List.of(bfActionTypeItem));
+
+        SubmitEvent submitEvent = new SubmitEvent();
+        submitEvent.setCaseId(123L);
+        submitEvent.setCaseData(caseData);
+        return submitEvent;
     }
 }

--- a/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/WaTaskCreationCronForExpiredBfActionsTest.java
+++ b/src/test/java/uk/gov/hmcts/ethos/replacement/docmosis/wa/WaTaskCreationCronForExpiredBfActionsTest.java
@@ -25,8 +25,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -92,6 +92,7 @@ class WaTaskCreationCronForExpiredBfActionsTest {
         verify(ccdClient, times(0))
                 .submitEventForCase(any(), any(), any(), any(), any(), any());
     }
+
     @Test
     void skipsCasesWithBfDateBeforeAugust2026() throws IOException {
         when(featureToggleService.isWaTaskForExpiredBfActionsEnabled()).thenReturn(true);


### PR DESCRIPTION
## Summary
- restrict expired BF work-allocation task searches to BF dates from 1 August 2026
- enforce the same cutoff when validating returned BF actions
- add boundary coverage for 31 July and 1 August 2026, and update the existing eligible-date fixture

## Testing
- `./gradlew test`