### PR TITLE
feat: add PostgreSQL read-only role and associated permissions

### DIFF
--- a/infrastructure/sdp-readonly-role.tf
+++ b/infrastructure/sdp-readonly-role.tf
@@ -1,0 +1,70 @@
+locals {
+  sdp_reader_name = "sdp_reader"
+  sdp_database    = "et_cos"
+  sdp_schema      = "ccd"
+}
+
+resource "random_password" "sdp_reader" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*+-=?@^_"
+}
+
+resource "postgresql_role" "sdp_reader" {
+  name                = local.sdp_reader_name
+  login               = true
+  password_wo         = random_password.sdp_reader.result
+  password_wo_version = random_password.sdp_reader.id
+
+  superuser                 = false
+  create_database           = false
+  create_role               = false
+  inherit                   = false
+  replication               = false
+  bypass_row_level_security = false
+  connection_limit          = 10
+}
+
+resource "postgresql_grant" "sdp_reader_database_connect" {
+  database    = local.sdp_database
+  role        = postgresql_role.sdp_reader.name
+  object_type = "database"
+  privileges  = ["CONNECT"]
+}
+
+resource "postgresql_grant" "sdp_reader_ccd_schema" {
+  database    = local.sdp_database
+  role        = postgresql_role.sdp_reader.name
+  schema      = local.sdp_schema
+  object_type = "schema"
+  privileges  = ["USAGE"]
+}
+
+resource "postgresql_grant" "sdp_reader_ccd_tables" {
+  database    = local.sdp_database
+  role        = postgresql_role.sdp_reader.name
+  schema      = local.sdp_schema
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+
+resource "postgresql_default_privileges" "sdp_reader_ccd_tables" {
+  database    = local.sdp_database
+  owner       = module.postgres.username
+  role        = postgresql_role.sdp_reader.name
+  schema      = local.sdp_schema
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+
+resource "azurerm_key_vault_secret" "sdp_postgres_readonly_user" {
+  name         = "sdp-postgres-readonly-user"
+  value        = postgresql_role.sdp_reader.name
+  key_vault_id = module.key-vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "sdp_postgres_readonly_password" {
+  name         = "sdp-postgres-readonly-password"
+  value        = random_password.sdp_reader.result
+  key_vault_id = module.key-vault.key_vault_id
+}

--- a/infrastructure/sdp-role-providers.tf
+++ b/infrastructure/sdp-role-providers.tf
@@ -1,0 +1,20 @@
+##
+## Additional providers required for the SDP read-only PostgreSQL login.
+## The postgresql provider connects to the Flexible Server through the module's
+## administrator credentials so that the LOGIN role can be created and granted
+## privileges at apply time.
+##
+
+
+provider "postgresql" {
+  host     = module.postgres.fqdn
+  port     = 5432
+  database = "et_cos"
+  username = module.postgres.username
+  password = module.postgres.password
+  sslmode  = "require"
+
+  # The Flexible Server is private; the runner executing terraform apply must
+  # have network access via VNet/bastion or private DNS resolution.
+  connect_timeout = 15
+}

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.79.0"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.26"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds the persistent `sdp_reader` PostgreSQL login for the `et_cos` database.
- Limits explicit access to `CONNECT` plus `USAGE` and `SELECT` on the `ccd` schema only; future `ccd` tables created by the database owner receive the same read access.
- Adds a 32-character generated password and stores the reader username and password in Key Vault as `sdp-postgres-readonly-user` and `sdp-postgres-readonly-password`.
- Adds the `cyrilgdn/postgresql` and `hashicorp/random` Terraform providers.

## Validation
- `terraform fmt -check` passes.