### PR TITLE
Test smoke stage without team secrets

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.9")
+@Library("Infrastructure@feature/optional-smoke-test-secrets")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 
@@ -102,6 +102,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, component) {
   env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
   loadVaultSecrets(secrets)
+  disableSmokeTestSecrets()
 //  enableHighLevelDataSetup()
   enableAksStagingDeployment()
   onMaster {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@feature/optional-smoke-test-secrets")
+@Library("Infrastructure@2.5.2")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 


### PR DESCRIPTION
## What changed

- use `Infrastructure@feature/optional-smoke-test-secrets` from hmcts/cnp-jenkins-library#1520
- call `disableSmokeTestSecrets()` for the ET application pipeline

## Why

This preview PR verifies that the ET smoke stage can run without loading the application team-secret set, while deployment and functional tests continue to receive their configured secrets.

## Prerequisite

- hmcts/cnp-jenkins-library#1522 must merge first so Jenkins permits the feature library branch

## Validation

- branch created from the latest `et-ccd-callbacks/master`
- `git diff --check`
- intentionally limited to `Jenkinsfile_CNP`; nightly configuration is unchanged