### PR TITLE
Reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,24 @@
+# ACR only needs the Dockerfile and the artefacts copied into the image.
+# Excluding the rest avoids uploading source, caches, dependencies and reports.
+**
+
+!Dockerfile
+
+!lib/
+!lib/applicationinsights.json
+
+!build/
+!build/libs/
+!build/libs/et-cos.jar
+!build/cftlib/
+!build/cftlib/definition-snapshots/
+!build/cftlib/definition-snapshots/**
+
+!ccd-definitions/
+!ccd-definitions/jurisdictions/
+!ccd-definitions/jurisdictions/**
+
+# These jurisdiction sources are not required by the running application.
 ccd-definitions/jurisdictions/*/data
 ccd-definitions/jurisdictions/*/xlsx
 ccd-definitions/jurisdictions/*/package.json


### PR DESCRIPTION
## Summary

- replace the broad Docker build context with an allow-list containing only files copied by the Dockerfile
- retain the existing exclusions for CCD source spreadsheets, data directories and package manifests
- exclude source code, dependency caches, `node_modules`, Gradle state and test/report output from ACR uploads

## Why

The Jenkins Docker stage runs `az acr build ... .`, but the previous `.dockerignore` excluded only three CCD paths. That meant ACR could scan and upload the rest of the populated workspace even though the image only copies the application JAR, Application Insights configuration, CCD jurisdiction runtime files and generated definition snapshots.

A smaller context should reduce upload and processing time and avoid scanning files that parallel checks may create or remove.

## Validation

- `./gradlew bootJar` completed successfully
- `docker build --progress=plain -t et-cos-docker-context-test .` completed successfully
- Docker received a 261.63 MB context from a 518 MB populated workspace
- every Dockerfile `COPY` completed successfully using the allow-list

The exact Jenkins timing improvement will be measured by builds on this PR.
