### PR TITLE
Reduce duplicate Key Vault lookups

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -36,10 +36,6 @@ def secrets = [
     secret('et-cos-s2s-secret', 'ET_COS_S2S_SECRET'),
     secret('cos-system-user', 'ET_COS_SYSTEM_USER'),
     secret('cos-system-user-password', 'ET_COS_SYSTEM_USER_PASSWORD'),
-    secret('cos-system-user', 'DEFINITION_IMPORTER_USERNAME'),
-    secret('cos-system-user-password', 'DEFINITION_IMPORTER_PASSWORD'),
-    secret('cos-system-user', 'ET_SYSTEM_USER'),
-    secret('cos-system-user-password', 'ET_SYSTEM_USER_PASSWORD'),
     secret('et-staff-user-admin-user-name', 'ET_STAFF_USER_ADMIN_USER_NAME'),
     secret('et-staff-user-admin-user-name-password', 'ET_STAFF_USER_ADMIN_USER_NAME_PASSWORD'),
     secret('et-cos-postgres-user-v15', 'ET_COS_AAT_DB_USER_NAME'),
@@ -74,16 +70,11 @@ def secrets = [
   's2s-${env}': [
     secret('microservicekey-ccd-data', 'DATA_STORE_S2S_KEY'),
     secret('microservicekey-ccd-definition', 'DEFINITION_STORE_S2S_KEY'),
-    secret('microservicekey-ccd-gw', 'API_GATEWAY_S2S_KEY'),
     secret('microservicekey-ccd-gw', 'MICROSERVICE_CCD_GW'),
     secret('microservicekey-ccd-ps', 'PRINT_S2S_KEY'),
     secret('microservicekey-ccd-admin', 'ADMIN_S2S_KEY'),
     secret('microservicekey-et-cos', 'ET_COS_S2S_KEY'),
-    secret('microservicekey-xui-webapp', 'XUI_S2S_KEY'),
-    secret('microservicekey-ccd-gw', 'CCD_API_GATEWAY_S2S_SECRET'),
-    secret('microservicekey-ccd-data', 'CCD_DATA_STORE_S2S_SECRET'),
-    secret('microservicekey-ccd-definition', 'CCD_DEFINITION_STORE_S2S_SECRET'),
-    secret('microservicekey-ccd-admin', 'ADMIN_S2S_KEY')
+    secret('microservicekey-xui-webapp', 'XUI_S2S_KEY')
   ],
   'ccd-${env}': [
     secret('ccd-api-gateway-oauth2-client-secret', 'API_GATEWAY_IDAM_SECRET'),

--- a/bin/preview/utils/auth-utils.sh
+++ b/bin/preview/utils/auth-utils.sh
@@ -111,7 +111,7 @@ get_service_token() {
     local s2s_secret
     case "${microservice}" in
         "ccd_gw")
-            s2s_secret="${API_GATEWAY_S2S_KEY:-}"
+            s2s_secret="${MICROSERVICE_CCD_GW:-}"
             ;;
         "ccd_data")
             s2s_secret="${DATA_STORE_S2S_KEY:-}"

--- a/charts/et-cos/values.preview.template.yaml
+++ b/charts/et-cos/values.preview.template.yaml
@@ -335,7 +335,7 @@ ccd:
       devmemoryRequests: 512Mi
       devmemoryLimits: 1024Mi
       environment:
-        IDAM_SERVICE_KEY: ${API_GATEWAY_S2S_KEY}
+        IDAM_SERVICE_KEY: ${MICROSERVICE_CCD_GW}
         IDAM_OAUTH2_CLIENT_SECRET: ${API_GATEWAY_IDAM_SECRET}
         CORS_ORIGIN_WHITELIST: "*"
         PROXY_CASE_ACTIVITY: http://${SERVICE_NAME}-ccd-case-activity-api


### PR DESCRIPTION
## Summary

- remove unused duplicate environment aliases for ET system-user credentials
- reuse the existing `MICROSERVICE_CCD_GW` binding in preview configuration
- remove duplicate S2S bindings where the same physical secret was requested more than once

## Why

The CNP pipeline loaded several Key Vault secrets repeatedly under different environment-variable names. Each binding results in a separate Key Vault lookup during secret-loading stages. This change removes nine duplicate lookups without changing vault names, secret names, or the shared Jenkins library.

## Expected impact

Secret-loading passes make nine fewer Key Vault requests. Based on observed pipeline logs this is a modest per-stage saving, but it is low-risk and applies anywhere this CNP secret map is loaded.

## Validation

- `./gradlew validateCcdDefinitionsLockfile`
- `bash -n bin/preview/utils/auth-utils.sh`
- focused shell check confirming `get_service_token ccd_gw` uses `MICROSERVICE_CCD_GW`
- verified the CNP secret map contains no repeated physical secret names
- `git diff --check`