### PR TITLE
RET-6943 - ACAS Docs API

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
@@ -92,6 +92,10 @@ public final class EtSyaConstants {
         "Notice of Preliminary Hearing");
     public static final List<String> ACAS_SERVING_DOCUMENTS =
         Stream.of(EW_ACAS_SERVING_DOCUMENTS, SCOT_ACAS_SERVING_DOCUMENTS).flatMap(List::stream).toList();
+    public static final List<String> NOTICE_OF_CLAIM_DOCUMENTS = List.of("2.6", "2.7", "2.8", "Letter 7",
+        "Letter 72 short track notice of claim and notice of hearing", "Letter 76 Notice of Claim", "Notice of Claim");
+    public static final List<String> NOTICE_OF_HEARING_DOCUMENTS =
+        List.of("7.7", "7.8", "7.8a", "Notice of Preliminary Hearing");
 
     private EtSyaConstants() {
         // restrict instantiation

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
@@ -4,6 +4,10 @@ import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Stream;
+
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.RESPONSE_ACCEPTED;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.RESPONSE_REJECTED;
 
 /**
  * Defines attributes used by et-sya-api as constants.
@@ -81,6 +85,13 @@ public final class EtSyaConstants {
     public static final String STRING_DASH = "-";
 
     public static final List<String> ACAS_VISIBLE_DOCS = List.of(ET1, ET1_ATTACHMENT, ET3, ET3_ATTACHMENT);
+    public static final List<String> ACAS_PHASE2_VISIBLE_DOCS = List.of(RESPONSE_REJECTED, RESPONSE_ACCEPTED);
+    public static final List<String> EW_ACAS_SERVING_DOCUMENTS = List.of("2.6", "2.7", "2.8", "7.7", "7.8", "7.8a");
+    public static final List<String> SCOT_ACAS_SERVING_DOCUMENTS = List.of("Letter 7", "Letter 72 short track notice "
+        + "of claim and notice of hearing", "Letter 75", "Letter 76 Notice of Claim", "Notice of Claim",
+        "Notice of Preliminary Hearing");
+    public static final List<String> ACAS_SERVING_DOCUMENTS =
+        Stream.of(EW_ACAS_SERVING_DOCUMENTS, SCOT_ACAS_SERVING_DOCUMENTS).flatMap(List::stream).toList();
 
     private EtSyaConstants() {
         // restrict instantiation

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/constants/EtSyaConstants.java
@@ -88,7 +88,7 @@ public final class EtSyaConstants {
     public static final List<String> ACAS_PHASE2_VISIBLE_DOCS = List.of(RESPONSE_REJECTED, RESPONSE_ACCEPTED);
     public static final List<String> EW_ACAS_SERVING_DOCUMENTS = List.of("2.6", "2.7", "2.8", "7.7", "7.8", "7.8a");
     public static final List<String> SCOT_ACAS_SERVING_DOCUMENTS = List.of("Letter 7", "Letter 72 short track notice "
-        + "of claim and notice of hearing", "Letter 75", "Letter 76 Notice of Claim", "Notice of Claim",
+        + "of claim and notice of hearing", "Letter 76 Notice of Claim", "Notice of Claim",
         "Notice of Preliminary Hearing");
     public static final List<String> ACAS_SERVING_DOCUMENTS =
         Stream.of(EW_ACAS_SERVING_DOCUMENTS, SCOT_ACAS_SERVING_DOCUMENTS).flatMap(List::stream).toList();

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
@@ -37,6 +37,8 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.postgresql.shaded.com.ongres.scram.common.util.Preconditions.isNullOrEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MAX_ES_SIZE;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_PHASE2_VISIBLE_DOCS;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_SERVING_DOCUMENTS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_VISIBLE_DOCS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ENGLAND_CASE_TYPE;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET1_ATTACHMENT;
@@ -63,6 +65,7 @@ public class AcasCaseService {
     private final CaseDocumentService caseDocumentService;
     @Qualifier("applicationTaskExecutor")
     private final TaskExecutor taskExecutor;
+    private final FeatureToggleService featureToggleService;
 
     /**
      * Given a datetime, this method will return a list of caseIds which have been modified since the datetime
@@ -194,14 +197,26 @@ public class AcasCaseService {
         return documentTypeItemList;
     }
 
-    private static List<DocumentTypeItem> getDocumentCollectionDocs(CaseData caseData) {
+    private List<DocumentTypeItem> getDocumentCollectionDocs(CaseData caseData) {
         if (CollectionUtils.isEmpty(caseData.getDocumentCollection())) {
             return new ArrayList<>();
         }
 
-        return caseData.getDocumentCollection().stream()
-            .filter(d -> !isNullOrEmpty(getDocumentType(d)) && ACAS_VISIBLE_DOCS.contains(getDocumentType(d)))
+        List<DocumentTypeItem> acasDocuments = new ArrayList<>();
+        List<String> acasVisibleDocs = new ArrayList<>(ACAS_VISIBLE_DOCS);
+        if (featureToggleService.isAcasDocumentsPhase2Enabled()) {
+            acasVisibleDocs.addAll(ACAS_PHASE2_VISIBLE_DOCS);
+            List<DocumentTypeItem> servingDocuments = caseData.getServingDocumentCollection().stream()
+                .filter(d -> !isNullOrEmpty(getDocumentType(d)) && ACAS_SERVING_DOCUMENTS.contains(getDocumentType(d)))
+                .toList();
+            acasDocuments.addAll(servingDocuments);
+        }
+
+        List<DocumentTypeItem> list = caseData.getDocumentCollection().stream()
+            .filter(d -> !isNullOrEmpty(getDocumentType(d)) && acasVisibleDocs.contains(getDocumentType(d)))
             .toList();
+        acasDocuments.addAll(list);
+        return acasDocuments;
     }
 
     private void retrieveRespondentDocuments(String authorisation, List<CaseDocumentAcasResponse> documents,

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
@@ -37,6 +37,8 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.postgresql.shaded.com.ongres.scram.common.util.Preconditions.isNullOrEmpty;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MAX_ES_SIZE;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.NOTICE_OF_CLAIM;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.NOTICE_OF_HEARING;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_PHASE2_VISIBLE_DOCS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_SERVING_DOCUMENTS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_VISIBLE_DOCS;
@@ -45,6 +47,8 @@ import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET1_ATTACHM
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET3;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ET3_ATTACHMENT;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.NO;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.NOTICE_OF_CLAIM_DOCUMENTS;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.NOTICE_OF_HEARING_DOCUMENTS;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.SCOTLAND_CASE_TYPE;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.YES;
 import static uk.gov.hmcts.reform.et.syaapi.helper.EmployeeObjectMapper.convertCaseDataMapToCaseDataObject;
@@ -206,8 +210,9 @@ public class AcasCaseService {
         List<String> acasVisibleDocs = new ArrayList<>(ACAS_VISIBLE_DOCS);
         if (featureToggleService.isAcasDocumentsPhase2Enabled()) {
             acasVisibleDocs.addAll(ACAS_PHASE2_VISIBLE_DOCS);
-            List<DocumentTypeItem> servingDocuments = caseData.getServingDocumentCollection().stream()
+            List<DocumentTypeItem> servingDocuments = emptyIfNull(caseData.getServingDocumentCollection()).stream()
                 .filter(d -> !isNullOrEmpty(getDocumentType(d)) && ACAS_SERVING_DOCUMENTS.contains(getDocumentType(d)))
+                .map(AcasCaseService::normaliseServingDocumentType)
                 .toList();
             acasDocuments.addAll(servingDocuments);
         }
@@ -217,6 +222,16 @@ public class AcasCaseService {
             .toList();
         acasDocuments.addAll(list);
         return acasDocuments;
+    }
+
+    private static DocumentTypeItem normaliseServingDocumentType(DocumentTypeItem document) {
+        String documentType = getDocumentType(document);
+        if (NOTICE_OF_CLAIM_DOCUMENTS.contains(documentType)) {
+            document.getValue().setDocumentType(NOTICE_OF_CLAIM);
+        } else if (NOTICE_OF_HEARING_DOCUMENTS.contains(documentType)) {
+            document.getValue().setDocumentType(NOTICE_OF_HEARING);
+        }
+        return document;
     }
 
     private void retrieveRespondentDocuments(String authorisation, List<CaseDocumentAcasResponse> documents,
@@ -311,11 +326,11 @@ public class AcasCaseService {
 
     private List<CaseData> searchAndReturnCaseDataList(String authorisation, String query) {
         List<CaseDetails> searchResults = searchEnglandScotlandCases(authorisation, query);
-        List<CaseData> caseDataList = new ArrayList<>();
-        for (CaseDetails caseDetails : searchResults) {
-            caseDataList.add(convertCaseDataMapToCaseDataObject(caseDetails.getData()));
-        }
-        return caseDataList;
+        return searchResults.stream()
+            .map(caseDetails -> ccdApiClient.getCase(authorisation, authTokenGenerator.generate(),
+                String.valueOf(caseDetails.getId())))
+            .map(ccdCaseDetails -> convertCaseDataMapToCaseDataObject(ccdCaseDetails.getData()))
+            .toList();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/FeatureToggleService.java
@@ -58,6 +58,10 @@ public class FeatureToggleService {
         return this.featureToggleApi.isFeatureEnabled("acasVetAndAccept");
     }
 
+    public boolean isAcasDocumentsPhase2Enabled() {
+        return this.featureToggleApi.isFeatureEnabled("acasDocumentsPhase2");
+    }
+
     /**
      * This method is used to check if the et3-self-assignment feature is enabled.
      * When enabled, supports professional user detection and already-assigned status.

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.task.TaskExecutor;
 import uk.gov.hmcts.ecm.common.model.helper.Constants;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
 import uk.gov.hmcts.et.common.model.ccd.types.UploadedDocumentType;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -18,6 +20,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants;
+import uk.gov.hmcts.reform.et.syaapi.helper.EmployeeObjectMapper;
 import uk.gov.hmcts.reform.et.syaapi.model.CaseTestData;
 import uk.gov.hmcts.reform.et.syaapi.models.CaseDocumentAcasResponse;
 import uk.gov.hmcts.reform.et.syaapi.service.utils.TestConstants;
@@ -28,9 +31,8 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,8 +48,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.NOTICE_OF_CLAIM;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.NOTICE_OF_HEARING;
 import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.RESPONSE_ACCEPTED;
-import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_SERVING_DOCUMENTS;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.NOTICE_OF_CLAIM_DOCUMENTS;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.NOTICE_OF_HEARING_DOCUMENTS;
 import static uk.gov.hmcts.reform.et.syaapi.service.utils.TestConstants.TEST_NAME;
 import static uk.gov.hmcts.reform.et.syaapi.service.utils.TestConstants.USER_ID;
 
@@ -265,11 +270,12 @@ class AcasCaseServiceTest {
     }
 
     @Test
-    void retrieveAcasDocuments_validReceiptDate() {
+    void shouldReturnVisibleAcasDocuments() {
         String caseId = EXAMPLE_CASE_ID;
+        CaseDetails caseDetails = caseDetailsWithAcasDocuments();
         SearchResult englandWalesSearchResult = SearchResult.builder()
             .total(1)
-            .cases(testData.getRequestCaseDataListEnglandAcas())
+            .cases(List.of(caseDetails))
             .build();
         SearchResult scotlandSearchResult = SearchResult.builder()
             .total(0)
@@ -277,73 +283,90 @@ class AcasCaseServiceTest {
             .build();
 
         when(ccdApiClient.searchCases(
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+            anyString(),
+            anyString(),
+            eq(EtSyaConstants.ENGLAND_CASE_TYPE), anyString()
         )).thenReturn(englandWalesSearchResult);
         when(ccdApiClient.searchCases(
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+            anyString(),
+            anyString(),
+            eq(EtSyaConstants.SCOTLAND_CASE_TYPE), anyString()
         )).thenReturn(scotlandSearchResult);
-        doCallRealMethod().when(caseDocumentService).createDocumentTypeItem(
-            isA(String.class), isA(UploadedDocumentType.class));
+        when(ccdApiClient.getCase(anyString(), anyString(), eq(caseId))).thenReturn(caseDetails);
 
         doCallRealMethod().when(caseDocumentService).getDocumentUuid(isA(String.class));
         when(caseDocumentService.getDocumentDetails(any(), any()))
             .thenReturn(TestDataProvider.getDocumentDetailsFromCdam());
         List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
         assertNotNull(documents);
-        assertThat(documents).hasSize(4);
+        assertThat(documents)
+            .extracting(CaseDocumentAcasResponse::getDocumentType)
+            .containsExactlyInAnyOrder("ET1", "ET3");
     }
 
     @Test
     void retrieveAcasDocumentsShouldIncludePhase2DocumentsWhenFeatureIsEnabled() {
-        String caseId = EXAMPLE_CASE_ID;
-        CaseDetails caseDetails = testData.getRequestCaseDataListEnglandAcas().getFirst();
-        Map<String, Object> caseData = caseDetails.getData();
-        List<Map<String, Object>> documentCollection = (List<Map<String, Object>>) caseData.get("documentCollection");
+        CaseDetails caseDetails = caseDetailsWithAcasDocuments();
+        CaseData caseData = EmployeeObjectMapper.convertCaseDataMapToCaseDataObject(caseDetails.getData());
+        List<DocumentTypeItem> documentCollection = new ArrayList<>(caseData.getDocumentCollection());
         documentCollection.add(document(RESPONSE_ACCEPTED, UUID.randomUUID().toString()));
-        caseData.put("servingDocumentCollection", List.of(document(ACAS_SERVING_DOCUMENTS.getFirst(),
-                                                                    UUID.randomUUID().toString())));
+        caseData.setDocumentCollection(documentCollection);
+        caseData.setServingDocumentCollection(List.of(
+            document(NOTICE_OF_CLAIM_DOCUMENTS.getFirst(), UUID.randomUUID().toString()),
+            document(NOTICE_OF_HEARING_DOCUMENTS.getFirst(), UUID.randomUUID().toString())
+        ));
+        caseDetails.setData(EmployeeObjectMapper.mapCaseDataToLinkedHashMap(caseData));
 
+        String caseId = EXAMPLE_CASE_ID;
         when(featureToggleService.isAcasDocumentsPhase2Enabled()).thenReturn(true);
         when(ccdApiClient.searchCases(
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+            anyString(),
+            anyString(),
+            eq(EtSyaConstants.ENGLAND_CASE_TYPE), anyString()
         )).thenReturn(SearchResult.builder().total(1).cases(List.of(caseDetails)).build());
         when(ccdApiClient.searchCases(
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            TestConstants.TEST_SERVICE_AUTH_TOKEN,
-            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+            anyString(),
+            anyString(),
+            eq(EtSyaConstants.SCOTLAND_CASE_TYPE), anyString()
         )).thenReturn(SearchResult.builder().total(0).cases(null).build());
-        doCallRealMethod().when(caseDocumentService).createDocumentTypeItem(
-            isA(String.class), isA(UploadedDocumentType.class));
+        when(ccdApiClient.getCase(anyString(), anyString(), eq(caseId))).thenReturn(caseDetails);
         doCallRealMethod().when(caseDocumentService).getDocumentUuid(isA(String.class));
         when(caseDocumentService.getDocumentDetails(any(), any()))
             .thenReturn(TestDataProvider.getDocumentDetailsFromCdam());
 
         List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
 
-        assertThat(documents).hasSize(6);
         assertThat(documents)
             .extracting(CaseDocumentAcasResponse::getDocumentType)
-            .contains(RESPONSE_ACCEPTED, ACAS_SERVING_DOCUMENTS.getFirst());
+            .containsExactlyInAnyOrder("ET1", "ET3", RESPONSE_ACCEPTED, NOTICE_OF_CLAIM, NOTICE_OF_HEARING);
     }
 
-    private Map<String, Object> document(String type, String documentId) {
-        return Map.of(
-            "id", documentId,
-            "value", Map.of(
-                "typeOfDocument", type,
-                "uploadedDocument", Map.of(
-                    "document_url", "http://document.binary.url/" + documentId,
-                    "document_filename", "document.pdf",
-                    "document_binary_url", "http://document.binary.url/" + documentId + "/binary"
-                )
-            )
-        );
+    private CaseDetails caseDetailsWithAcasDocuments() {
+        CaseData caseData = new CaseData();
+        caseData.setDocumentCollection(List.of(
+            document("ET1", UUID.randomUUID().toString()),
+            document("ET3", UUID.randomUUID().toString())
+        ));
+        return CaseDetails.builder()
+            .id(Long.valueOf(EXAMPLE_CASE_ID))
+            .data(EmployeeObjectMapper.mapCaseDataToLinkedHashMap(caseData))
+            .build();
+    }
+
+    private DocumentTypeItem document(String type, String documentId) {
+        UploadedDocumentType uploadedDocument = new UploadedDocumentType();
+        uploadedDocument.setDocumentUrl("http://document.binary.url/" + documentId);
+        uploadedDocument.setDocumentFilename("document.pdf");
+        uploadedDocument.setDocumentBinaryUrl("http://document.binary.url/" + documentId + "/binary");
+
+        DocumentType documentType = new DocumentType();
+        documentType.setTypeOfDocument(type);
+        documentType.setUploadedDocument(uploadedDocument);
+
+        DocumentTypeItem documentTypeItem = new DocumentTypeItem();
+        documentTypeItem.setId(documentId);
+        documentTypeItem.setValue(documentType);
+        return documentTypeItem;
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
@@ -30,6 +30,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,6 +46,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.EMPLOYMENT;
+import static uk.gov.hmcts.ecm.common.model.helper.DocumentConstants.RESPONSE_ACCEPTED;
+import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ACAS_SERVING_DOCUMENTS;
 import static uk.gov.hmcts.reform.et.syaapi.service.utils.TestConstants.TEST_NAME;
 import static uk.gov.hmcts.reform.et.syaapi.service.utils.TestConstants.USER_ID;
 
@@ -63,6 +67,8 @@ class AcasCaseServiceTest {
     private CaseDocumentService caseDocumentService;
     @Mock
     private TaskExecutor taskExecutor;
+    @Mock
+    private FeatureToggleService featureToggleService;
     @InjectMocks
     private AcasCaseService acasCaseService;
     private final CaseTestData testData;
@@ -289,6 +295,55 @@ class AcasCaseServiceTest {
         List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
         assertNotNull(documents);
         assertThat(documents).hasSize(4);
+    }
+
+    @Test
+    void retrieveAcasDocumentsShouldIncludePhase2DocumentsWhenFeatureIsEnabled() {
+        String caseId = EXAMPLE_CASE_ID;
+        CaseDetails caseDetails = testData.getRequestCaseDataListEnglandAcas().getFirst();
+        Map<String, Object> caseData = caseDetails.getData();
+        List<Map<String, Object>> documentCollection = (List<Map<String, Object>>) caseData.get("documentCollection");
+        documentCollection.add(document(RESPONSE_ACCEPTED, UUID.randomUUID().toString()));
+        caseData.put("servingDocumentCollection", List.of(document(ACAS_SERVING_DOCUMENTS.getFirst(),
+                                                                    UUID.randomUUID().toString())));
+
+        when(featureToggleService.isAcasDocumentsPhase2Enabled()).thenReturn(true);
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.ENGLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(SearchResult.builder().total(1).cases(List.of(caseDetails)).build());
+        when(ccdApiClient.searchCases(
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            TestConstants.TEST_SERVICE_AUTH_TOKEN,
+            EtSyaConstants.SCOTLAND_CASE_TYPE, generateCaseDataEsQuery(Collections.singletonList(caseId))
+        )).thenReturn(SearchResult.builder().total(0).cases(null).build());
+        doCallRealMethod().when(caseDocumentService).createDocumentTypeItem(
+            isA(String.class), isA(UploadedDocumentType.class));
+        doCallRealMethod().when(caseDocumentService).getDocumentUuid(isA(String.class));
+        when(caseDocumentService.getDocumentDetails(any(), any()))
+            .thenReturn(TestDataProvider.getDocumentDetailsFromCdam());
+
+        List<CaseDocumentAcasResponse> documents = acasCaseService.retrieveAcasDocuments(caseId);
+
+        assertThat(documents).hasSize(6);
+        assertThat(documents)
+            .extracting(CaseDocumentAcasResponse::getDocumentType)
+            .contains(RESPONSE_ACCEPTED, ACAS_SERVING_DOCUMENTS.getFirst());
+    }
+
+    private Map<String, Object> document(String type, String documentId) {
+        return Map.of(
+            "id", documentId,
+            "value", Map.of(
+                "typeOfDocument", type,
+                "uploadedDocument", Map.of(
+                    "document_url", "http://document.binary.url/" + documentId,
+                    "document_filename", "document.pdf",
+                    "document_binary_url", "http://document.binary.url/" + documentId + "/binary"
+                )
+            )
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/FeatureToggleServiceTest.java
@@ -81,6 +81,14 @@ class FeatureToggleServiceTest {
         assertThat(featureToggleService.isAcasVetAndAcceptEnabled()).isEqualTo(toggleStat);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnCorrectValueWhenAcasDocumentsPhase2IsEnabled(boolean toggleStat) {
+        givenToggle("acasDocumentsPhase2", toggleStat);
+
+        assertThat(featureToggleService.isAcasDocumentsPhase2Enabled()).isEqualTo(toggleStat);
+    }
+
     private void givenToggle(String feature, boolean state) {
         when(featureToggleApi.isFeatureEnabled(feature)).thenReturn(state);
     }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/RET-6943

### Change description

- Add Serving related documents to the `getAcasDocuments` API
- Added a feature toggle to control the deployment on non-prod and prod environments