### PR TITLE
Update hmcts.ccd.sdk version to 6.36.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.freefair.lombok' version '8.14.4'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'pmd'
-    id 'hmcts.ccd.sdk' version '6.35.0'
+    id 'hmcts.ccd.sdk' version '6.36.0'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.2274'
 }
 


### PR DESCRIPTION
Improves performance for cases with large numbers of case events by excluding json blob payloads from bulk event fetching.
