### PR TITLE
Wait for IDAM login form before creating sessions

### DIFF
--- a/src/test/e2e/pages/claimantCitizenHub/CitizenHubLoginPage.ts
+++ b/src/test/e2e/pages/claimantCitizenHub/CitizenHubLoginPage.ts
@@ -10,7 +10,6 @@ export default class CitizenHubLoginPage extends LoginPage {
   private readonly returnTodraftClaimCheckbox: Locator;
   private readonly returntoSubmittedClaimCheckbox: Locator;
   private readonly employmentTribunalAccountCheckbox: Locator;
-  private readonly signInOptionLink: Locator;
   private readonly returnToDraftOrSubmittedClaimPageTitle: Locator;
 
   constructor(page: Page) {
@@ -23,7 +22,6 @@ export default class CitizenHubLoginPage extends LoginPage {
     this.returnTodraftClaimCheckbox = this.page.locator(`#return_to_existing`);
     this.returntoSubmittedClaimCheckbox = this.page.locator(`#return_to_existing-2`);
     this.employmentTribunalAccountCheckbox = this.page.locator(`#submitted_claim_option`);
-    this.signInOptionLink = page.locator('//a[@href="/enter-email"]');
   }
 
   async assertSyaLandingPage() {
@@ -55,12 +53,6 @@ export default class CitizenHubLoginPage extends LoginPage {
     await this.page.waitForLoadState('load');
     await this.employmentTribunalAccountCheckbox.check();
     await this.clickContinue();
-    const isNewIdam = await this.signInOptionLink.isVisible().catch(() => false);
-    if(isNewIdam) { // Remove if condition when new IDAM is rolled out to all environments
-      await this.signInOptionLink.click();
-      await this.page.waitForLoadState('load');
-    }
-    if (await this.signOutLink.isVisible({ timeout: 2000 }).catch(() => false)) return;
     await this.processLogin(user, config.etSyaUiUrl);
     //TODO remove url check to landing page, as UI will be logged as soon as user is created.
     const url = this.page.url();

--- a/src/test/e2e/pages/loginPage.ts
+++ b/src/test/e2e/pages/loginPage.ts
@@ -28,9 +28,11 @@ export default class LoginPage extends BasePage {
   }
 
   async processLogin(user: UserCredentials, baseUrl : string = aatUrl) {
-    await this.page.waitForTimeout(1000);
     await this.page.waitForLoadState('load');
-    if (await this.signOutLink.count() > 0 || await this.username.count() === 0) {
+
+    await expect(this.username.or(this.signOutLink).first()).toBeVisible({ timeout: 10000 });
+
+    if (await this.signOutLink.isVisible()) {
       // Do not overwrite the canonical session file when a context is already authenticated.
       return;
     }

--- a/src/test/e2e/pages/loginPage.ts
+++ b/src/test/e2e/pages/loginPage.ts
@@ -10,6 +10,7 @@ export default class LoginPage extends BasePage {
   private readonly username: Locator;
   private readonly password: Locator;
   private readonly signInOrContinueOrSubmitButton: Locator;
+  private readonly signInOptionLink: Locator;
   readonly signOutLink: Locator;
 
   constructor(page: Page) {
@@ -19,6 +20,7 @@ export default class LoginPage extends BasePage {
     this.password = page.locator('[data-testid="idam-password-input"], #password, input[name="password"], input[type="password"]');
     this.signInOrContinueOrSubmitButton = page.locator('[data-testid="idam-submit-button"], [name="save"], button[type="submit"], input[type="submit"]')
       .filter({ hasText: /Sign in|Continue/i });
+    this.signInOptionLink = page.locator('a[href="/enter-email"]');
     this.signOutLink = page.locator(`//a[normalize-space()='Sign out']`)
   }
 
@@ -30,12 +32,25 @@ export default class LoginPage extends BasePage {
   async processLogin(user: UserCredentials, baseUrl : string = aatUrl) {
     await this.page.waitForLoadState('load');
 
-    await expect(this.username.or(this.signOutLink).first()).toBeVisible({ timeout: 10000 });
+    await expect.poll(async () => {
+      const [isSignedIn, hasSignInOption, hasUsername] = await Promise.all([
+        this.signOutLink.isVisible(),
+        this.signInOptionLink.isVisible(),
+        this.username.isVisible(),
+      ]);
+      return isSignedIn || hasSignInOption || hasUsername;
+    }).toBeTruthy();
 
     if (await this.signOutLink.isVisible()) {
       // Do not overwrite the canonical session file when a context is already authenticated.
       return;
     }
+
+    if (await this.signInOptionLink.isVisible()) {
+      await this.signInOptionLink.click();
+    }
+
+    await expect(this.username).toBeVisible();
     const currentHeading = await this.headingText();
 
     if (currentHeading === 'Sign in or create an account' || currentHeading === 'Sign in') {

--- a/src/test/e2e/pages/respondentCitizenHub/et3LoginPage.ts
+++ b/src/test/e2e/pages/respondentCitizenHub/et3LoginPage.ts
@@ -14,7 +14,6 @@ export default class Et3LoginPage extends LoginPage {
   private readonly appointLegalRepLink: Locator;
   private readonly errorMessage = (text: string): Locator => this.page.getByText(text).first();
   private readonly etAccountRadio: Locator;
-  private readonly signInOptionLink: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -28,7 +27,6 @@ export default class Et3LoginPage extends LoginPage {
     this.claimantLastName = page.locator('#claimantLastName');
     this.appointLegalRepLink = page.locator('[href="/appoint-legal-representative"]');
     this.etAccountRadio = page.locator(`#return_number_or_account-2`);
-    this.signInOptionLink = page.locator('//a[@href="/enter-email"]');
   }
 
   async processRespondentLogin(user: UserCredentials) {
@@ -38,11 +36,6 @@ export default class Et3LoginPage extends LoginPage {
     await this.page.waitForTimeout(1000);
     await this.etAccountRadio.click();
     await this.clickContinue();
-    const isNewIdam = await this.signInOptionLink.isVisible().catch(() => false);
-    if(isNewIdam) { // Remove if condition when new IDAM is rolled out to all environments
-      await this.signInOptionLink.click();
-      await this.page.waitForLoadState('load');
-    }
     await this.processLogin(user, config.etSyrUiUrl);
     await this.page.waitForLoadState('load');
   }


### PR DESCRIPTION
Prevents Playwright setup from silently completing while the IDAM login controls are still loading. The setup now waits for either the login form or a confirmed signed-in state, so dependent tests do not fail later because their session file was never created.